### PR TITLE
Remove unneeded Cesium.isArray usage

### DIFF
--- a/lib/ForEach.js
+++ b/lib/ForEach.js
@@ -3,7 +3,6 @@ const Cesium = require('cesium');
 const hasExtension = require('./hasExtension');
 
 const defined = Cesium.defined;
-const isArray = Cesium.isArray;
 
 module.exports = ForEach;
 
@@ -58,7 +57,7 @@ ForEach.object = function(arrayOfObjects, handler) {
  */
 ForEach.topLevel = function(gltf, name, handler) {
     const gltfProperty = gltf[name];
-    if (defined(gltfProperty) && !isArray(gltfProperty)) {
+    if (defined(gltfProperty) && !Array.isArray(gltfProperty)) {
         return ForEach.objectLegacy(gltfProperty, handler);
     }
 

--- a/lib/removeExtension.js
+++ b/lib/removeExtension.js
@@ -4,7 +4,6 @@ const ForEach = require('./ForEach');
 const removeExtensionsUsed = require('./removeExtensionsUsed');
 
 const defined = Cesium.defined;
-const isArray = Cesium.isArray;
 
 module.exports = removeExtension;
 
@@ -37,7 +36,7 @@ function removeCesiumRTC(gltf) {
 }
 
 function removeExtensionAndTraverse(object, extension) {
-    if (isArray(object)) {
+    if (Array.isArray(object)) {
         const length = object.length;
         for (let i = 0; i < length; ++i) {
             removeExtensionAndTraverse(object[i], extension);

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -17,7 +17,6 @@ const clone = Cesium.clone;
 const ComponentDatatype = Cesium.ComponentDatatype;
 const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
-const isArray = Cesium.isArray;
 const Matrix4 = Cesium.Matrix4;
 const Quaternion = Cesium.Quaternion;
 const WebGLConstants = Cesium.WebGLConstants;
@@ -572,7 +571,7 @@ function removeEmptyArrays(gltf) {
     for (const topLevelId in gltf) {
         if (Object.prototype.hasOwnProperty.call(gltf, topLevelId)) {
             const array = gltf[topLevelId];
-            if (isArray(array) && array.length === 0) {
+            if (Array.isArray(array) && array.length === 0) {
                 delete gltf[topLevelId];
             }
         }


### PR DESCRIPTION
`Cesium.isArray` is deprecated and Node code should just be calling `Array.isArray` directly anyway.