### PR TITLE
Clone options before modifying options

### DIFF
--- a/lib/gltfToGlb.js
+++ b/lib/gltfToGlb.js
@@ -3,7 +3,7 @@ const Cesium = require('cesium');
 const getJsonBufferPadded = require('./getJsonBufferPadded');
 const processGltf = require('./processGltf');
 
-const defaultValue = Cesium.defaultValue;
+const clone = Cesium.clone;
 const defined = Cesium.defined;
 
 module.exports = gltfToGlb;
@@ -16,7 +16,7 @@ module.exports = gltfToGlb;
  * @returns {Promise} A promise that resolves to a buffer containing the glb contents.
  */
 function gltfToGlb(gltf, options) {
-    options = defaultValue(options, {});
+    options = defined(options) ? clone(options) : {};
     options.bufferStorage = {
         buffer: undefined
     };

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -12,6 +12,7 @@ const updateVersion = require('./updateVersion');
 const writeResources = require('./writeResources');
 const compressDracoMeshes = require('./compressDracoMeshes');
 
+const clone = Cesium.clone;
 const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
@@ -35,7 +36,7 @@ module.exports = processGltf;
  */
 function processGltf(gltf, options) {
     const defaults = processGltf.defaults;
-    options = defaultValue(options, {});
+    options = defined(options) ? clone(options) : {};
     options.separateBuffers = defaultValue(options.separate, defaults.separate);
     options.separateShaders = defaultValue(options.separate, defaults.separate);
     options.separateTextures = defaultValue(options.separateTextures, defaults.separateTextures) || options.separate;


### PR DESCRIPTION
This PR clones the options object before setting internal properties to it.

This resulted in a race condition in https://github.com/CesiumGS/3d-tiles-validator/pull/186 where calls to `gltfToGlb` and `processGltf` were sharing the same options object that was getting modified internally by gltf-pipeline.