### PR TITLE
Don't delete nodes that have used descendants

### DIFF
--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -431,27 +431,24 @@ getListOfElementsIdsInUse.mesh = function(gltf) {
 
 // Check if node is empty. It is considered empty if neither referencing
 // mesh, camera, extensions and has no children
-function nodeIsEmpty(gltf, node) {
+function nodeIsEmpty(gltf, nodeId, usedNodeIds) {
+    const node = gltf.nodes[nodeId];
     if (defined(node.mesh) || defined(node.camera) || defined(node.skin)
         || defined(node.weights) || defined(node.extras)
-        || (defined(node.extensions) && node.extensions.length !== 0)) {
+        || (defined(node.extensions) && Object.keys(node.extensions).length !== 0)
+        || defined(usedNodeIds[nodeId])) {
         return false;
     }
 
     // Empty if no children or children are all empty nodes
     return !defined(node.children)
         || node.children.filter(function(n) {
-            return !nodeIsEmpty(gltf, gltf.nodes[n]);
+            return !nodeIsEmpty(gltf, n, usedNodeIds);
         }).length === 0;
 }
 
 getListOfElementsIdsInUse.node = function(gltf) {
     const usedNodeIds = {};
-    ForEach.node(gltf, function(node, nodeId) {
-        if (!nodeIsEmpty(gltf, node)) {
-            usedNodeIds[nodeId] = true;
-        }
-    });
     ForEach.skin(gltf, function(skin) {
         if (defined(skin.skeleton)) {
             usedNodeIds[skin.skeleton] = true;
@@ -474,6 +471,11 @@ getListOfElementsIdsInUse.node = function(gltf) {
                 usedNodeIds[uniform.node] = true;
             }
         });
+    });
+    ForEach.node(gltf, function(node, nodeId) {
+        if (!nodeIsEmpty(gltf, nodeId, usedNodeIds)) {
+            usedNodeIds[nodeId] = true;
+        }
     });
 
     return usedNodeIds;

--- a/specs/lib/removeUnusedElementsSpec.js
+++ b/specs/lib/removeUnusedElementsSpec.js
@@ -441,6 +441,106 @@ describe('removeUnusedElements', () => {
             expect(remaining['lights']).toContain(element.name);
         });
     });
+
+    it('keeps ancestor nodes of used nodes', () => {
+        const gltf = {
+            nodes: [
+                {
+                    name: 'skeleton-root',
+                    skin: 0,
+                    mesh: 0,
+                    translation: [0.0, 0.0, 0.0]
+                },
+                {
+                    name: 'joint-parent',
+                    translation: [0.0, 0.0, 0.0],
+                    children: [2]
+                },
+                {
+                    name: 'joint',
+                    translation: [0.0, 0.0, 0.0]
+                },
+                {
+                    name: 'unused'
+                }
+            ],
+            buffers: [
+                {
+                    name: 'mesh',
+                    byteLength: 246,
+                    uri: 'data0.bin'
+                },
+                {
+                    name: 'other',
+                    byteLength: 80,
+                    uri: 'data1.bin'
+                }
+            ],
+            bufferViews: [
+                {
+                    name: 'positions',
+                    buffer: 0,
+                    byteOffset: 0,
+                    byteLength: 36
+                },
+                {
+                    name: 'indices',
+                    buffer: 0,
+                    byteOffset: 240,
+                    byteLength: 6
+                }
+            ],
+            accessors: [
+                {
+                    name: 'positions',
+                    bufferView: 0,
+                    byteOffset: 0,
+                    componentType: WebGLConstants.FLOAT,
+                    count: 3,
+                    type: 'VEC3',
+                    min: [-1.0, -1.0, -1.0],
+                    max: [1.0, 1.0, 1.0]
+                },
+                {
+                    name: 'indices',
+                    bufferView: 7,
+                    byteOffset: 240,
+                    componentType: WebGLConstants.UNSIGNED_SHORT,
+                    count: 3,
+                    type: 'SCALAR'
+                }
+            ],
+            meshes: [
+                {
+                    name: 'mesh0',
+                    primitives: [
+                        {
+                            attributes: {
+                                POSITION: 0
+                            },
+                            indices: 1,
+                            mode: WebGLConstants.TRIANGLES
+                        }
+                    ]
+                }
+            ],
+            skins: [
+                {
+                    skeleton: 0,
+                    joints: [0, 2]
+                }
+            ],
+            scenes: [
+                {
+                    nodes: [0]
+                }
+            ]
+        };
+
+        removeUnusedElements(gltf);
+
+        expect(gltf.nodes.length).toEqual(3);
+    });
 });
 
 describe('removes unused materials, textures, images, samplers', () => {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/gltf-pipeline/issues/532

Don't delete a node if it has a descendant that's used for skinning or animation. In the case of #532 a parent of a node in the skin's joints list was being removed. I confirmed the test passes in this branch but not in master.