### PR TITLE
Rename to EXT_mesh_gpu_instancing

### DIFF
--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -342,11 +342,11 @@ getListOfElementsIdsInUse.accessor = function(gltf) {
         });
     });
 
-    if (hasExtension(gltf, 'EXT_gpu_mesh_instancing')) {
+    if (hasExtension(gltf, 'EXT_mesh_gpu_instancing')) {
         ForEach.node(gltf, function(node) {
-            if (defined(node.extensions) && defined(node.extensions.EXT_gpu_mesh_instancing)) {
-                Object.keys(node.extensions.EXT_gpu_mesh_instancing.attributes).forEach(function(key) {
-                    const attributeAccessorId = node.extensions.EXT_gpu_mesh_instancing.attributes[key];
+            if (defined(node.extensions) && defined(node.extensions.EXT_mesh_gpu_instancing)) {
+                Object.keys(node.extensions.EXT_mesh_gpu_instancing.attributes).forEach(function(key) {
+                    const attributeAccessorId = node.extensions.EXT_mesh_gpu_instancing.attributes[key];
                     usedAccessorIds[attributeAccessorId] = true;
                 });
             }

--- a/specs/lib/removeUnusedElementsSpec.js
+++ b/specs/lib/removeUnusedElementsSpec.js
@@ -871,7 +871,7 @@ describe('removes unused materials, textures, images, samplers', () => {
         expect(gltf.textures[0].sampler).toEqual(0);
     });
 
-    it('does not remove EXT_gpu_mesh_instancing accessors', () => {
+    it('does not remove EXT_mesh_gpu_instancing accessors', () => {
         const gltf = {
             accessors: [
                 {
@@ -893,7 +893,7 @@ describe('removes unused materials, textures, images, samplers', () => {
             nodes: [
                 {
                     extensions: {
-                        EXT_gpu_mesh_instancing: {
+                        EXT_mesh_gpu_instancing: {
                             attributes: {
                                 TRANSLATION: 1,
                                 ROTATION: 2,
@@ -903,7 +903,7 @@ describe('removes unused materials, textures, images, samplers', () => {
                     }
                 }
             ],
-            extensionsUsed: [ 'EXT_gpu_mesh_instancing' ]
+            extensionsUsed: [ 'EXT_mesh_gpu_instancing' ]
         };
 
         removeUnusedElements(gltf, ['accessor']);


### PR DESCRIPTION
Rename `EXT_gpu_mesh_instancing` to `EXT_mesh_gpu_instancing`. I should have caught this while reviewing https://github.com/CesiumGS/gltf-pipeline/pull/535.