### PR TITLE
Fix CesiumJS build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,7 +189,7 @@ function amdify(source, subDependencyMapping) {
     const lines = [];
     for (const variable in requireMapping) {
         if (Object.prototype.hasOwnProperty.call(requireMapping, variable)) {
-            lines.push('import ' + variable + ' from \'' + requireMapping[variable] + '\'');
+            lines.push('import ' + variable + ' from "' + requireMapping[variable] + '.js"');
         }
     }
     let defineHeader = '';

--- a/lib/forEachTextureInMaterial.js
+++ b/lib/forEachTextureInMaterial.js
@@ -1,7 +1,10 @@
 'use strict';
+const Cesium = require('cesium');
 
-const { Check, defined } = require('cesium');
 const ForEach = require('./ForEach');
+
+const Check = Cesium.Check;
+const defined = Cesium.defined;
 
 module.exports = forEachTextureInMaterial;
 


### PR DESCRIPTION
Fixes gltf-pipeline bundled in CesiumJS

* Add `.js` to the end of each import
* Changed formatting of imports in `forEachTextureMaterial` so that it's compatible with the `build-cesium` gulp task