### PR TITLE
Change Draco modules to be created asynchronously

### DIFF
--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -23,9 +23,6 @@ const defined = Cesium.defined;
 const RuntimeError = Cesium.RuntimeError;
 const WebGLConstants = Cesium.WebGLConstants;
 
-// Prepare encoder for compressing meshes.
-const encoderModule = draco3d.createEncoderModule({});
-
 module.exports = compressDracoMeshes;
 
 /**
@@ -57,6 +54,7 @@ function compressDracoMeshes(gltf, options) {
     const quantizationVolume = dracoOptions.quantizationVolume;
     const explicitQuantization = unifiedQuantization || defined(quantizationVolume);
     const quantizationBitsValues = getQuantizationBits(dracoOptions);
+    const encoderModule = dracoOptions.encoderModule;
 
     checkRange('compressionLevel', compressionLevel, 0, 10);
     for (const attributeName in quantizationBitsValues) {
@@ -196,7 +194,8 @@ function compressDracoMeshes(gltf, options) {
                 numberOfPoints: encoder.GetNumberOfEncodedPoints(),
                 numberOfFaces: encoder.GetNumberOfEncodedFaces()
             };
-            addCompressionExtensionToPrimitive(gltf, primitive, attributeToId, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues);
+            const decoderModule = dracoOptions.decoderModule;
+            addCompressionExtensionToPrimitive(decoderModule, gltf, primitive, attributeToId, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues);
 
             encoderModule.destroy(encodedDracoDataArray);
             encoderModule.destroy(mesh);
@@ -243,7 +242,7 @@ function addIndices(gltf, primitive) {
     primitive.indices = addToArray(gltf.accessors, accessor);
 }
 
-function addCompressionExtensionToPrimitive(gltf, primitive, attributeToId, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues) {
+function addCompressionExtensionToPrimitive(decoderModule, gltf, primitive, attributeToId, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues) {
     if (!uncompressedFallback) {
         // Remove properties from accessors.
         // Remove indices bufferView.
@@ -269,7 +268,7 @@ function addCompressionExtensionToPrimitive(gltf, primitive, attributeToId, drac
         attributes: attributeToId
     };
 
-    gltf = replaceWithDecompressedPrimitive(gltf, primitive, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues);
+    gltf = replaceWithDecompressedPrimitive(decoderModule, gltf, primitive, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues);
 }
 
 function copyCompressedExtensionToPrimitive(primitive, compressedPrimitive) {

--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -1,6 +1,5 @@
 'use strict';
 const Cesium = require('cesium');
-const draco3d = require('draco3d');
 const hashObject = require('object-hash');
 const addBuffer = require('./addBuffer');
 const addExtensionsRequired = require('./addExtensionsRequired');

--- a/lib/replaceWithDecompressedPrimitive.js
+++ b/lib/replaceWithDecompressedPrimitive.js
@@ -8,8 +8,6 @@ const defined = Cesium.defined;
 const RuntimeError = Cesium.RuntimeError;
 const WebGLConstants = Cesium.WebGLConstants;
 
-const decoderModule = draco3d.createDecoderModule({});
-
 module.exports = replaceWithDecompressedPrimitive;
 
 /**
@@ -27,7 +25,7 @@ module.exports = replaceWithDecompressedPrimitive;
  *
  * @private
  */
-function replaceWithDecompressedPrimitive(gltf, primitive, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues) {
+function replaceWithDecompressedPrimitive(decoderModule, gltf, primitive, dracoEncodedBuffer, uncompressedFallback, quantizationBitsValues) {
     let decoder;
     let dracoGeometry;
 
@@ -37,7 +35,7 @@ function replaceWithDecompressedPrimitive(gltf, primitive, dracoEncodedBuffer, u
 
     if (uncompressedFallback) {
         decoder = new decoderModule.Decoder();
-        dracoGeometry = decompressDracoBuffer(decoder, dracoEncodedBuffer.buffer);
+        dracoGeometry = decompressDracoBuffer(decoderModule, decoder, dracoEncodedBuffer.buffer);
 
         const indicesBuffer = getIndicesBuffer(indicesAccessor, decoderModule, decoder, dracoGeometry, dracoEncodedBuffer.numberOfFaces);
 
@@ -75,7 +73,7 @@ function replaceWithDecompressedPrimitive(gltf, primitive, dracoEncodedBuffer, u
     return gltf;
 }
 
-function decompressDracoBuffer(decoder, compressedData) {
+function decompressDracoBuffer(decoderModule, decoder, compressedData) {
     const source = new Uint8Array(compressedData.buffer);
     const dracoBuffer = new decoderModule.DecoderBuffer();
     dracoBuffer.Init(source, source.length);

--- a/lib/replaceWithDecompressedPrimitive.js
+++ b/lib/replaceWithDecompressedPrimitive.js
@@ -1,6 +1,5 @@
 'use strict';
 const Cesium = require('cesium');
-const draco3d = require('draco3d');
 const addBuffer = require('./addBuffer');
 const numberOfComponentsForType = require('./numberOfComponentsForType');
 

--- a/specs/lib/compressDracoMeshesSpec.js
+++ b/specs/lib/compressDracoMeshesSpec.js
@@ -1,5 +1,6 @@
 'use strict';
 const { AxisAlignedBoundingBox, Cartesian3, clone, DeveloperError} = require('cesium');
+const draco3d = require('draco3d');
 const fsExtra = require('fs-extra');
 const readResources = require('../../lib/readResources');
 const compressDracoMeshes = require('../../lib/compressDracoMeshes');
@@ -38,202 +39,206 @@ function getDracoBuffer(gltf) {
     return source.slice(bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength);
 }
 
-describe('compressDracoMeshes', () => {
-    beforeEach(async () => {
-        gltf = await readGltf(boxPath);
-        gltfOther = await readGltf(boxPath);
-    });
+describe('compressDracoMeshes', () => function() {
+    draco3d.createEncoderModule({}).then(function(module) {
+        {
+            beforeEach(async () => {
+                gltf = await readGltf(boxPath);
+                gltfOther = await readGltf(boxPath);
+            });
 
-    it('compresses meshes with default options', () => {
-        expect(gltf.accessors.length).toBe(4); // 3 attributes + indices
-        expect(gltf.bufferViews.length).toBe(4); // position/normal + texcoord + indices + image
+            it('compresses meshes with default options', () => {
+                expect(gltf.accessors.length).toBe(4); // 3 attributes + indices
+                expect(gltf.bufferViews.length).toBe(4); // position/normal + texcoord + indices + image
 
-        compressDracoMeshes(gltf);
+                compressDracoMeshes(gltf);
 
-        expect(gltf.accessors.length).toBe(4); // accessors are not removed
-        expect(gltf.bufferViews.length).toBe(2); // draco + image
+                expect(gltf.accessors.length).toBe(4); // accessors are not removed
+                expect(gltf.bufferViews.length).toBe(2); // draco + image
 
-        const dracoExtension = gltf.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
-        expect(dracoExtension.bufferView).toBeDefined();
-        expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
-        expect(gltf.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                const dracoExtension = gltf.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+                expect(dracoExtension.bufferView).toBeDefined();
+                expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                expect(gltf.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
 
-        const positionAccessor = gltf.accessors[dracoExtension.attributes.POSITION];
-        const normalAccessor = gltf.accessors[dracoExtension.attributes.NORMAL];
-        const texcoordAccessor = gltf.accessors[dracoExtension.attributes.TEXCOORD_0];
+                const positionAccessor = gltf.accessors[dracoExtension.attributes.POSITION];
+                const normalAccessor = gltf.accessors[dracoExtension.attributes.NORMAL];
+                const texcoordAccessor = gltf.accessors[dracoExtension.attributes.TEXCOORD_0];
 
-        expect(positionAccessor.bufferView).toBeUndefined();
-        expect(positionAccessor.byteLength).toBeUndefined();
-        expect(normalAccessor.bufferView).toBeUndefined();
-        expect(normalAccessor.byteLength).toBeUndefined();
-        expect(texcoordAccessor.bufferView).toBeUndefined();
-        expect(texcoordAccessor.byteLength).toBeUndefined();
-    });
+                expect(positionAccessor.bufferView).toBeUndefined();
+                expect(positionAccessor.byteLength).toBeUndefined();
+                expect(normalAccessor.bufferView).toBeUndefined();
+                expect(normalAccessor.byteLength).toBeUndefined();
+                expect(texcoordAccessor.bufferView).toBeUndefined();
+                expect(texcoordAccessor.byteLength).toBeUndefined();
+            });
 
-    it('compresses mesh without indices', async () => {
-        const gltf = await readGltf(triangleWithoutIndicesPath);
-        expect(gltf.accessors.length).toBe(1); // positions
-        expect(gltf.bufferViews.length).toBe(1); // positions
+            it('compresses mesh without indices', async () => {
+                const gltf = await readGltf(triangleWithoutIndicesPath);
+                expect(gltf.accessors.length).toBe(1); // positions
+                expect(gltf.bufferViews.length).toBe(1); // positions
 
-        compressDracoMeshes(gltf);
+                compressDracoMeshes(gltf);
 
-        expect(gltf.accessors.length).toBe(2); // positions + indices
-        expect(gltf.bufferViews.length).toBe(1); // draco
+                expect(gltf.accessors.length).toBe(2); // positions + indices
+                expect(gltf.bufferViews.length).toBe(1); // draco
 
-        const dracoExtension = gltf.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
-        expect(dracoExtension.bufferView).toBeDefined();
-        expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
-        expect(gltf.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                const dracoExtension = gltf.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+                expect(dracoExtension.bufferView).toBeDefined();
+                expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                expect(gltf.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
 
-        const positionAccessor = gltf.accessors[dracoExtension.attributes.POSITION];
-        expect(positionAccessor.bufferView).toBeUndefined();
-        expect(positionAccessor.byteLength).toBeUndefined();
-    });
+                const positionAccessor = gltf.accessors[dracoExtension.attributes.POSITION];
+                expect(positionAccessor.bufferView).toBeUndefined();
+                expect(positionAccessor.byteLength).toBeUndefined();
+            });
 
-    it('throws if quantize bits is out of range', () => {
-        expectOutOfRange(gltf, 'compressionLevel', -1);
-        expectOutOfRange(gltf, 'compressionLevel', 11);
-        expectOutOfRange(gltf, 'quantizePositionBits', -1);
-        expectOutOfRange(gltf, 'quantizePositionBits', 31);
-        expectOutOfRange(gltf, 'quantizeNormalBits', -1);
-        expectOutOfRange(gltf, 'quantizeNormalBits', 31);
-        expectOutOfRange(gltf, 'quantizeTexcoordBits', -1);
-        expectOutOfRange(gltf, 'quantizeTexcoordBits', 31);
-        expectOutOfRange(gltf, 'quantizeColorBits', -1);
-        expectOutOfRange(gltf, 'quantizeColorBits', 31);
-        expectOutOfRange(gltf, 'quantizeGenericBits', -1);
-        expectOutOfRange(gltf, 'quantizeGenericBits', 31);
-    });
+            it('throws if quantize bits is out of range', () => {
+                expectOutOfRange(gltf, 'compressionLevel', -1);
+                expectOutOfRange(gltf, 'compressionLevel', 11);
+                expectOutOfRange(gltf, 'quantizePositionBits', -1);
+                expectOutOfRange(gltf, 'quantizePositionBits', 31);
+                expectOutOfRange(gltf, 'quantizeNormalBits', -1);
+                expectOutOfRange(gltf, 'quantizeNormalBits', 31);
+                expectOutOfRange(gltf, 'quantizeTexcoordBits', -1);
+                expectOutOfRange(gltf, 'quantizeTexcoordBits', 31);
+                expectOutOfRange(gltf, 'quantizeColorBits', -1);
+                expectOutOfRange(gltf, 'quantizeColorBits', 31);
+                expectOutOfRange(gltf, 'quantizeGenericBits', -1);
+                expectOutOfRange(gltf, 'quantizeGenericBits', 31);
+            });
 
-    it('applies unified quantization', async () => {
-        const gltfUnified = await readGltf(multipleBoxesPath);
-        const gltfNonUnified = await readGltf(multipleBoxesPath);
-        compressDracoMeshes(gltfUnified, {
-            dracoOptions: {
-                unifiedQuantization: true
+            it('applies unified quantization', async () => {
+                const gltfUnified = await readGltf(multipleBoxesPath);
+                const gltfNonUnified = await readGltf(multipleBoxesPath);
+                compressDracoMeshes(gltfUnified, {
+                    dracoOptions: {
+                        unifiedQuantization: true
+                    }
+                });
+                compressDracoMeshes(gltfNonUnified, {
+                    dracoOptions: {
+                        unifiedQuantization: false
+                    }
+                });
+                const dracoBufferUnified = getDracoBuffer(gltfUnified);
+                const dracoBufferNonUnified = getDracoBuffer(gltfNonUnified);
+                expect(dracoBufferNonUnified).not.toEqual(dracoBufferUnified);
+            });
+
+            it('uses explicit quantization volume', async () => {
+                const gltfVolume = await readGltf(multipleBoxesPath);
+                const gltfUnified = await readGltf(multipleBoxesPath);
+                const gltfDefault = await readGltf(multipleBoxesPath);
+                const aabb = new AxisAlignedBoundingBox(new Cartesian3(-10.0, -10.0, -10.0), new Cartesian3(10.0, 10.0, 10.0));
+                compressDracoMeshes(gltfVolume, {
+                    dracoOptions: {
+                        quantizationVolume: aabb
+                    }
+                });
+                compressDracoMeshes(gltfUnified, {
+                    dracoOptions: {
+                        unifiedQuantization: true
+                    }
+                });
+                compressDracoMeshes(gltfDefault, {
+                    dracoOptions: {}
+                });
+                const dracoBufferVolume = getDracoBuffer(gltfVolume);
+                const dracoBufferUnified = getDracoBuffer(gltfUnified);
+                const dracoBufferDefault = getDracoBuffer(gltfDefault);
+                expect(dracoBufferVolume).not.toEqual(dracoBufferDefault);
+                expect(dracoBufferVolume).not.toEqual(dracoBufferUnified);
+            });
+
+            it('applies quantization bits', () => {
+                compressDracoMeshes(gltf, {
+                    dracoOptions: {
+                        quantizePositionBits: 8
+                    }
+                });
+                compressDracoMeshes(gltfOther, {
+                    dracoOptions: {
+                        quantizePositionBits: 25
+                    }
+                });
+
+                const dracoBuffer8 = getDracoBuffer(gltf);
+                const dracoBuffer14 = getDracoBuffer(gltfOther);
+                expect(dracoBuffer8.length).toBeLessThan(dracoBuffer14.length);
+            });
+
+            it('does not quantize when quantize bits is 0', () => {
+                compressDracoMeshes(gltf, {
+                    dracoOptions: {
+                        quantizePositionBits: 0,
+                        quantizeNormalBits: 0,
+                        quantizeTexcoordBits: 0,
+                        quantizeColorBits: 0,
+                        quantizeGenericBits: 0
+                    }
+                });
+                compressDracoMeshes(gltfOther);
+                const dracoBufferUncompressed = getDracoBuffer(gltf);
+                const dracoBufferCompressed = getDracoBuffer(gltfOther);
+                expect(dracoBufferCompressed.length).toBeLessThan(dracoBufferUncompressed.length);
+            });
+
+            it('only compresses duplicate primitive once', () => {
+                const primitives = gltf.meshes[0].primitives;
+                primitives.push(clone(primitives[0], true));
+                compressDracoMeshes(gltf);
+                expect(primitives[0]).toEqual(primitives[1]);
+            });
+
+            function removeMorphTargets(gltf) {
+                const mesh = gltf.meshes[0];
+                const primitive = mesh.primitives[0];
+                delete primitive.targets;
+                delete mesh.weights;
+                return gltf;
             }
-        });
-        compressDracoMeshes(gltfNonUnified, {
-            dracoOptions: {
-                unifiedQuantization: false
-            }
-        });
-        const dracoBufferUnified = getDracoBuffer(gltfUnified);
-        const dracoBufferNonUnified = getDracoBuffer(gltfNonUnified);
-        expect(dracoBufferNonUnified).not.toEqual(dracoBufferUnified);
-    });
 
-    it('uses explicit quantization volume', async () => {
-        const gltfVolume = await readGltf(multipleBoxesPath);
-        const gltfUnified = await readGltf(multipleBoxesPath);
-        const gltfDefault = await readGltf(multipleBoxesPath);
-        const aabb = new AxisAlignedBoundingBox(new Cartesian3(-10.0, -10.0, -10.0), new Cartesian3(10.0, 10.0, 10.0));
-        compressDracoMeshes(gltfVolume, {
-            dracoOptions: {
-                quantizationVolume: aabb
-            }
-        });
-        compressDracoMeshes(gltfUnified, {
-            dracoOptions: {
-                unifiedQuantization: true
-            }
-        });
-        compressDracoMeshes(gltfDefault, {
-            dracoOptions: {}
-        });
-        const dracoBufferVolume = getDracoBuffer(gltfVolume);
-        const dracoBufferUnified = getDracoBuffer(gltfUnified);
-        const dracoBufferDefault = getDracoBuffer(gltfDefault);
-        expect(dracoBufferVolume).not.toEqual(dracoBufferDefault);
-        expect(dracoBufferVolume).not.toEqual(dracoBufferUnified);
-    });
+            it('applied sequential encoding when the primitive has morph targets', async () => {
+                const gltfMorph = await readGltf(boxMorphPath);
+                const gltfNoMorph = removeMorphTargets(await readGltf(boxMorphPath));
 
-    it('applies quantization bits', () => {
-        compressDracoMeshes(gltf, {
-            dracoOptions: {
-                quantizePositionBits: 8
-            }
-        });
-        compressDracoMeshes(gltfOther, {
-            dracoOptions: {
-                quantizePositionBits: 25
-            }
-        });
+                compressDracoMeshes(gltfMorph);
+                compressDracoMeshes(gltfNoMorph);
+                const dracoBufferMorph = getDracoBuffer(gltfMorph);
+                const dracoBufferNoMorph = getDracoBuffer(gltfNoMorph);
+                expect(dracoBufferMorph).not.toEqual(dracoBufferNoMorph);
+            });
 
-        const dracoBuffer8 = getDracoBuffer(gltf);
-        const dracoBuffer14 = getDracoBuffer(gltfOther);
-        expect(dracoBuffer8.length).toBeLessThan(dracoBuffer14.length);
-    });
+            it('applies uncompressed fallback', () => {
+                compressDracoMeshes(gltf, {
+                    dracoOptions: {
+                        uncompressedFallback: true
+                    }
+                });
+                compressDracoMeshes(gltfOther, {
+                    dracoOptions: {
+                        uncompressedFallback: false
+                    }
+                });
 
-    it('does not quantize when quantize bits is 0', () => {
-        compressDracoMeshes(gltf, {
-            dracoOptions: {
-                quantizePositionBits: 0,
-                quantizeNormalBits: 0,
-                quantizeTexcoordBits: 0,
-                quantizeColorBits: 0,
-                quantizeGenericBits: 0
-            }
-        });
-        compressDracoMeshes(gltfOther);
-        const dracoBufferUncompressed = getDracoBuffer(gltf);
-        const dracoBufferCompressed = getDracoBuffer(gltfOther);
-        expect(dracoBufferCompressed.length).toBeLessThan(dracoBufferUncompressed.length);
-    });
+                expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                expect(gltf.extensionsRequired).toBeUndefined();
+                expect(gltfOther.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                expect(gltfOther.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
+                expect(gltf.buffers.length).toBe(6); // draco + image + 4 uncompressed attributes
+                expect(gltfOther.buffers.length).toBe(2); // draco + image
 
-    it('only compresses duplicate primitive once', () => {
-        const primitives = gltf.meshes[0].primitives;
-        primitives.push(clone(primitives[0], true));
-        compressDracoMeshes(gltf);
-        expect(primitives[0]).toEqual(primitives[1]);
-    });
+                expect(gltf.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
+                expect(gltf.buffers[1].extras._pipeline.mergedBufferName).toBe('draco');
+                expect(gltf.buffers[2].extras._pipeline.mergedBufferName).toBe('uncompressed');
+                expect(gltf.buffers[3].extras._pipeline.mergedBufferName).toBe('uncompressed');
+                expect(gltf.buffers[4].extras._pipeline.mergedBufferName).toBe('uncompressed');
+                expect(gltf.buffers[5].extras._pipeline.mergedBufferName).toBe('uncompressed');
 
-    function removeMorphTargets(gltf) {
-        const mesh = gltf.meshes[0];
-        const primitive = mesh.primitives[0];
-        delete primitive.targets;
-        delete mesh.weights;
-        return gltf;
-    }
-
-    it('applied sequential encoding when the primitive has morph targets', async () => {
-        const gltfMorph = await readGltf(boxMorphPath);
-        const gltfNoMorph = removeMorphTargets(await readGltf(boxMorphPath));
-
-        compressDracoMeshes(gltfMorph);
-        compressDracoMeshes(gltfNoMorph);
-        const dracoBufferMorph = getDracoBuffer(gltfMorph);
-        const dracoBufferNoMorph = getDracoBuffer(gltfNoMorph);
-        expect(dracoBufferMorph).not.toEqual(dracoBufferNoMorph);
-    });
-
-    it('applies uncompressed fallback', () => {
-        compressDracoMeshes(gltf, {
-            dracoOptions: {
-                uncompressedFallback: true
-            }
-        });
-        compressDracoMeshes(gltfOther, {
-            dracoOptions: {
-                uncompressedFallback: false
-            }
-        });
-
-        expect(gltf.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
-        expect(gltf.extensionsRequired).toBeUndefined();
-        expect(gltfOther.extensionsUsed.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
-        expect(gltfOther.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
-        expect(gltf.buffers.length).toBe(6); // draco + image + 4 uncompressed attributes
-        expect(gltfOther.buffers.length).toBe(2); // draco + image
-
-        expect(gltf.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
-        expect(gltf.buffers[1].extras._pipeline.mergedBufferName).toBe('draco');
-        expect(gltf.buffers[2].extras._pipeline.mergedBufferName).toBe('uncompressed');
-        expect(gltf.buffers[3].extras._pipeline.mergedBufferName).toBe('uncompressed');
-        expect(gltf.buffers[4].extras._pipeline.mergedBufferName).toBe('uncompressed');
-        expect(gltf.buffers[5].extras._pipeline.mergedBufferName).toBe('uncompressed');
-
-        expect(gltfOther.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
-        expect(gltfOther.buffers[1].extras._pipeline.mergedBufferName).toBeUndefined();
-    });
-});
+                expect(gltfOther.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
+                expect(gltfOther.buffers[1].extras._pipeline.mergedBufferName).toBeUndefined();
+            });
+        } // scope
+    }); // createEncoder
+}); // describe

--- a/specs/lib/compressDracoMeshesSpec.js
+++ b/specs/lib/compressDracoMeshesSpec.js
@@ -39,6 +39,14 @@ function getDracoBuffer(gltf) {
     return source.slice(bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength);
 }
 
+function removeMorphTargets(gltf) {
+    const mesh = gltf.meshes[0];
+    const primitive = mesh.primitives[0];
+    delete primitive.targets;
+    delete mesh.weights;
+    return gltf;
+}
+
 describe('compressDracoMeshes', () => function() {
     draco3d.createEncoderModule({}).then(function(module) {
         {
@@ -190,14 +198,6 @@ describe('compressDracoMeshes', () => function() {
                 compressDracoMeshes(gltf);
                 expect(primitives[0]).toEqual(primitives[1]);
             });
-
-            function removeMorphTargets(gltf) {
-                const mesh = gltf.meshes[0];
-                const primitive = mesh.primitives[0];
-                delete primitive.targets;
-                delete mesh.weights;
-                return gltf;
-            }
 
             it('applied sequential encoding when the primitive has morph targets', async () => {
                 const gltfMorph = await readGltf(boxMorphPath);

--- a/specs/lib/processGltfSpec.js
+++ b/specs/lib/processGltfSpec.js
@@ -1,4 +1,5 @@
 'use strict';
+const draco3d = require('draco3d');
 const fsExtra = require('fs-extra');
 const path = require('path');
 const hasExtension = require('../../lib/hasExtension');
@@ -9,140 +10,144 @@ const gltfSeparatePath = 'specs/data/2.0/box-techniques-separate/box-techniques-
 const gltfWebpPath = 'specs/data/2.0/extensions/EXT_texture_webp/box-textured-embedded/box-textured-embedded.gltf';
 const gltfWebpSeparatePath = 'specs/data/2.0/extensions/EXT_texture_webp/box-textured-separate/box-textured-separate.gltf';
 
-describe('processGltf', () => {
-    it('processes gltf with default options', async () => {
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const results = await processGltf(gltf);
-        expect(results.gltf).toBeDefined();
-    });
+describe('processGltf', () => function() {
+    draco3d.createEncoderModule({}).then(function(module) {
+        {
+            it('processes gltf with default options', async () => {
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const results = await processGltf(gltf);
+                expect(results.gltf).toBeDefined();
+            });
 
-    it('uses resource directory', async () => {
-        const gltf = fsExtra.readJsonSync(gltfSeparatePath);
-        const options = {
-            resourceDirectory: path.dirname(gltfSeparatePath)
-        };
-        const results = await processGltf(gltf, options);
-        expect(results.gltf).toBeDefined();
-    });
+            it('uses resource directory', async () => {
+                const gltf = fsExtra.readJsonSync(gltfSeparatePath);
+                const options = {
+                    resourceDirectory: path.dirname(gltfSeparatePath)
+                };
+                const results = await processGltf(gltf, options);
+                expect(results.gltf).toBeDefined();
+            });
 
-    it('saves separate resources', async () => {
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            separate: true
-        };
-        const results = await processGltf(gltf, options);
-        expect(results.gltf).toBeDefined();
-        expect(Object.keys(results.separateResources).length).toBe(4);
-        expect(results.separateResources['Image0001.png']).toBeDefined();
-        expect(results.separateResources['CesiumTexturedBoxTest.bin']).toBeDefined();
-        expect(results.separateResources['CesiumTexturedBoxTest0FS.glsl']).toBeDefined();
-        expect(results.separateResources['CesiumTexturedBoxTest0VS.glsl']).toBeDefined();
-    });
+            it('saves separate resources', async () => {
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    separate: true
+                };
+                const results = await processGltf(gltf, options);
+                expect(results.gltf).toBeDefined();
+                expect(Object.keys(results.separateResources).length).toBe(4);
+                expect(results.separateResources['Image0001.png']).toBeDefined();
+                expect(results.separateResources['CesiumTexturedBoxTest.bin']).toBeDefined();
+                expect(results.separateResources['CesiumTexturedBoxTest0FS.glsl']).toBeDefined();
+                expect(results.separateResources['CesiumTexturedBoxTest0VS.glsl']).toBeDefined();
+            });
 
-    it('saves separate textures', async () => {
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            separateTextures: true
-        };
-        const results = await processGltf(gltf, options);
-        expect(results.gltf).toBeDefined();
-        expect(Object.keys(results.separateResources).length).toBe(1);
-        expect(results.separateResources['Image0001.png']).toBeDefined();
-        expect(results.gltf.buffers[0].uri.indexOf('data') >= 0).toBe(true);
-    });
+            it('saves separate textures', async () => {
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    separateTextures: true
+                };
+                const results = await processGltf(gltf, options);
+                expect(results.gltf).toBeDefined();
+                expect(Object.keys(results.separateResources).length).toBe(1);
+                expect(results.separateResources['Image0001.png']).toBeDefined();
+                expect(results.gltf.buffers[0].uri.indexOf('data') >= 0).toBe(true);
+            });
 
-    it('uses name to save separate resources', async () => {
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            separate: true,
-            name: 'my-model'
-        };
+            it('uses name to save separate resources', async () => {
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    separate: true,
+                    name: 'my-model'
+                };
 
-        delete gltf.buffers[0].name;
-        delete gltf.images[0].name;
-        delete gltf.extensions.KHR_techniques_webgl.programs[0].name;
-        delete gltf.extensions.KHR_techniques_webgl.shaders[0].name;
+                delete gltf.buffers[0].name;
+                delete gltf.images[0].name;
+                delete gltf.extensions.KHR_techniques_webgl.programs[0].name;
+                delete gltf.extensions.KHR_techniques_webgl.shaders[0].name;
 
-        const results = await processGltf(gltf, options);
-        expect(results.gltf).toBeDefined();
-        expect(results.separateResources['my-model0.png']).toBeDefined();
-        expect(results.separateResources['my-model.bin']).toBeDefined();
-        expect(results.separateResources['my-modelFS0.glsl']).toBeDefined();
-        expect(results.separateResources['my-modelFS0.glsl']).toBeDefined();
-    });
+                const results = await processGltf(gltf, options);
+                expect(results.gltf).toBeDefined();
+                expect(results.separateResources['my-model0.png']).toBeDefined();
+                expect(results.separateResources['my-model.bin']).toBeDefined();
+                expect(results.separateResources['my-modelFS0.glsl']).toBeDefined();
+                expect(results.separateResources['my-modelFS0.glsl']).toBeDefined();
+            });
 
-    it('prints stats', async () => {
-        spyOn(console, 'log');
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            stats: true
-        };
-        await processGltf(gltf, options);
-        expect(console.log).toHaveBeenCalled();
-    });
+            it('prints stats', async () => {
+                spyOn(console, 'log');
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    stats: true
+                };
+                await processGltf(gltf, options);
+                expect(console.log).toHaveBeenCalled();
+            });
 
-    it('uses draco compression', async () => {
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            dracoOptions: {
-                compressionLevel: 7
-            }
-        };
-        const results = await processGltf(gltf, options);
-        expect(hasExtension(results.gltf, 'KHR_draco_mesh_compression')).toBe(true);
-    });
+            it('uses draco compression', async () => {
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    dracoOptions: {
+                        compressionLevel: 7
+                    }
+                };
+                const results = await processGltf(gltf, options);
+                expect(hasExtension(results.gltf, 'KHR_draco_mesh_compression')).toBe(true);
+            });
 
-    it('runs custom stages', async () => {
-        spyOn(console, 'log');
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            customStages: [
-                (gltf) => {
-                    gltf.meshes[0].name = 'new-name';
-                },
-                (gltf) => {
-                    console.log(gltf.meshes[0].name);
-                }
-            ]
-        };
-        await processGltf(gltf, options);
-        expect(console.log).toHaveBeenCalledWith('new-name');
-    });
+            it('runs custom stages', async () => {
+                spyOn(console, 'log');
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    customStages: [
+                        (gltf) => {
+                            gltf.meshes[0].name = 'new-name';
+                        },
+                        (gltf) => {
+                            console.log(gltf.meshes[0].name);
+                        }
+                    ]
+                };
+                await processGltf(gltf, options);
+                expect(console.log).toHaveBeenCalledWith('new-name');
+            });
 
-    it('uses logger', async () => {
-        let loggedMessages = 0;
-        const gltf = fsExtra.readJsonSync(gltfPath);
-        const options = {
-            stats: true,
-            logger: () => {
-                loggedMessages++;
-            }
-        };
-        await processGltf(gltf, options);
-        expect(loggedMessages).toBe(2);
-    });
+            it('uses logger', async () => {
+                let loggedMessages = 0;
+                const gltf = fsExtra.readJsonSync(gltfPath);
+                const options = {
+                    stats: true,
+                    logger: () => {
+                        loggedMessages++;
+                    }
+                };
+                await processGltf(gltf, options);
+                expect(loggedMessages).toBe(2);
+            });
 
-    it('processes gltf with EXT_texture_webp extension.', async () => {
-        const gltf = fsExtra.readJsonSync(gltfWebpSeparatePath);
-        const options = {
-            resourceDirectory: path.dirname(gltfWebpSeparatePath)
-        };
-        const results = await processGltf(gltf, options);
-        expect(results.gltf).toBeDefined();
-        expect(results.gltf.textures[0].extensions.EXT_texture_webp).toBeDefined();
+            it('processes gltf with EXT_texture_webp extension.', async () => {
+                const gltf = fsExtra.readJsonSync(gltfWebpSeparatePath);
+                const options = {
+                    resourceDirectory: path.dirname(gltfWebpSeparatePath)
+                };
+                const results = await processGltf(gltf, options);
+                expect(results.gltf).toBeDefined();
+                expect(results.gltf.textures[0].extensions.EXT_texture_webp).toBeDefined();
 
-        const imageId = results.gltf.textures[0].extensions.EXT_texture_webp.source;
-        expect(results.gltf.images[imageId].mimeType).toBe('image/webp');
-    });
+                const imageId = results.gltf.textures[0].extensions.EXT_texture_webp.source;
+                expect(results.gltf.images[imageId].mimeType).toBe('image/webp');
+            });
 
-    it('processes embedded gltf with EXT_texture_webp extension.', async () => {
-        const gltf = fsExtra.readJsonSync(gltfWebpPath);
+            it('processes embedded gltf with EXT_texture_webp extension.', async () => {
+                const gltf = fsExtra.readJsonSync(gltfWebpPath);
 
-        const results = await processGltf(gltf);
-        expect(results.gltf).toBeDefined();
-        expect(results.gltf.textures[0].extensions.EXT_texture_webp).toBeDefined();
+                const results = await processGltf(gltf);
+                expect(results.gltf).toBeDefined();
+                expect(results.gltf.textures[0].extensions.EXT_texture_webp).toBeDefined();
 
-        const imageId = results.gltf.textures[0].extensions.EXT_texture_webp.source;
-        expect(results.gltf.images[imageId].mimeType).toBe('image/webp');
-    });
-});
+                const imageId = results.gltf.textures[0].extensions.EXT_texture_webp.source;
+                expect(results.gltf.images[imageId].mimeType).toBe('image/webp');
+            });
+        } // scope
+    }); // createEncoder
+}); // describe


### PR DESCRIPTION
In general Draco npm modules have always been created asynchronously. But in gltf-pipeline they worked usually with getting created synchronously.

We are planning to release Draco 1.4.0, which uses a new version of emscripten and causes gltf-pipline to fail as the timing has changed.

The change in this PR makes it so the current version of the Draco npm modules work and it will work when 1.4.0 is released.

The question is is there a better way to create the Draco modules asynchronously in gltf-pipeline?