### PR TITLE
Lock draco to 1.3.6 temporarily

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 3.0.1 - 2020-11-14
+
+* Locked Draco npm dependency to version 1.3.6 to avoid module initialization errors in 1.4.0. [#563](https://github.com/CesiumGS/gltf-pipeline/pull/563)
+
 ### 3.0.0 - 2020-07-22
 
 * Breaking changes

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "cesium": "^1.69.0",
-    "draco3d": "^1.3.6",
+    "draco3d": "1.3.6",
     "fs-extra": "^9.0.0",
     "mime": "^2.4.5",
     "object-hash": "^2.0.3",


### PR DESCRIPTION
Part of https://github.com/CesiumGS/gltf-pipeline/pull/561

gltf-pipeline initializes Draco modules in a way that will break once Draco 1.4.0 is released. This PR temporarily locks Draco to 1.3.6 so that projects that use gltf-pipeline can upgrade to gltf-pipeline 3.0.1 and not automatically pull Draco 1.4.0.

One annoyance is that a proposed fix https://github.com/CesiumGS/gltf-pipeline/pull/562 only works in Draco 1.4.0, not 1.3.6, for unknown reasons, so it complicates the order of events here.

The steps are:

* [ ] Merge this PR
* [ ] Publish gltf-pipeline 3.0.1
* [ ] Wait for Draco 1.4.0 release
* [ ] Merge https://github.com/CesiumGS/gltf-pipeline/pull/562 and add back caret symbol to `package.json`
* [ ] Publish gltf-pipeline 3.0.2

Projects will need to upgrade to gltf-pipeline 3.0.1 or 3.0.2 once they are released.