### PR TITLE
Set quantizeTexcoordBits default to 12 like docs

### DIFF
--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -370,7 +370,7 @@ compressDracoMeshes.defaults = {
     compressionLevel: 7,
     quantizePositionBits: 11,
     quantizeNormalBits: 8,
-    quantizeTexcoordBits: 10,
+    quantizeTexcoordBits: 12,
     quantizeColorBits: 8,
     quantizeSkinBits: 8,
     quantizeGenericBits: 8,


### PR DESCRIPTION
README.md says quantizeTexcoordBits default is 12. I found 10 to make the texture look wavy so I suggest changing this instead of the readme value to 10.