### PR TITLE
Delete uri property when parsing binary_glTF buffer (glTF 1.0)

### DIFF
--- a/lib/parseGlb.js
+++ b/lib/parseGlb.js
@@ -77,6 +77,7 @@ function parseGlbVersion1(glb, header) {
         const binaryGltfBuffer = defaultValue(buffers.binary_glTF, buffers.KHR_binary_glTF);
         if (defined(binaryGltfBuffer)) {
             binaryGltfBuffer.extras._pipeline.source = binaryBuffer;
+            delete binaryGltfBuffer.uri;
         }
     }
     // Remove the KHR_binary_glTF extension

--- a/specs/lib/parseGlbSpec.js
+++ b/specs/lib/parseGlbSpec.js
@@ -64,7 +64,8 @@ describe('parseGlb', () => {
                 },
                 buffers: {
                     binary_glTF: {
-                        byteLength: binaryData.length
+                        byteLength: binaryData.length,
+                        uri: 'data:,'
                     }
                 },
                 images: {
@@ -106,6 +107,7 @@ describe('parseGlb', () => {
             const buffer = parsedGltf.buffers.binary_glTF;
             for (let i = 0; i < binaryData.length; i++) {
                 expect(buffer.extras._pipeline.source[i]).toEqual(binaryData[i]);
+                expect(buffer.uri).toBeUndefined();
             }
 
             const image = parsedGltf.images.image;


### PR DESCRIPTION
This PR deletes the uri property of the `binary_glTF` buffer, which is meant to be ignored because the binary chunk should be used instead. Without this fix the glTF 1.0 to 2.0 update step may produce an invalid buffer.

From the [KHR_binary_glTF](https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF) glTF 1.0 extension:

> ...a runtime can ignore the `uri` property since the buffer refers to the Binary glTF `body` section, not an external resource. When a runtime encounters this buffer, it should use the Binary glTF `body` as the buffer.

Here's what a glTF like this looks like. A fake `uri` is used because [`buffer.schema.json`](https://github.com/KhronosGroup/glTF/blob/de6f8b5327959a61b77f280a95bf01b0c2681a6d/specification/1.0/schema/buffer.schema.json#L32) requires that `uri` exists. The `uri` would be deleted after this change.

```
  "buffers": {
    "binary_glTF": {
      "type": "arraybuffer",
      "byteLength": 13790,
      "uri": "data:,"
    }
  },
```