### PR TITLE
Fix name of spec gloss extension in addDefaults

### DIFF
--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -122,7 +122,7 @@ function addDefaults(gltf) {
             addTextureDefaults(pbrMetallicRoughness.metallicRoughnessTexture);
         }
 
-        const pbrSpecularGlossiness = extensions.pbrSpecularGlossiness;
+        const pbrSpecularGlossiness = extensions.KHR_materials_pbrSpecularGlossiness;
         if (defined(pbrSpecularGlossiness)) {
             pbrSpecularGlossiness.diffuseFactor = defaultValue(pbrSpecularGlossiness.diffuseFactor, [1.0, 1.0, 1.0, 1.0]);
             pbrSpecularGlossiness.specularFactor = defaultValue(pbrSpecularGlossiness.specularFactor, [1.0, 1.0, 1.0]);

--- a/specs/lib/addDefaultsSpec.js
+++ b/specs/lib/addDefaultsSpec.js
@@ -189,7 +189,7 @@ describe('addDefaults', () => {
             materials: [
                 {
                     extensions: {
-                        pbrSpecularGlossiness: {
+                        KHR_materials_pbrSpecularGlossiness: {
                             specularGlossinessTexture: {
                                 index: 0
                             }
@@ -199,7 +199,7 @@ describe('addDefaults', () => {
             ]
         };
         const gltfWithDefaults = addDefaults(gltf);
-        const pbrSpecularGlossiness = gltfWithDefaults.materials[0].extensions.pbrSpecularGlossiness;
+        const pbrSpecularGlossiness = gltfWithDefaults.materials[0].extensions.KHR_materials_pbrSpecularGlossiness;
 
         expect(pbrSpecularGlossiness.diffuseFactor).toEqual([1.0, 1.0, 1.0, 1.0]);
         expect(pbrSpecularGlossiness.specularFactor).toEqual([1.0, 1.0, 1.0]);


### PR DESCRIPTION
The name was `pbrSpecularGlossiness` and has been fixed to be `KHR_materials_pbrSpecularGlossiness`