### PR TITLE
Add support for EXT_feature_metadata in removeUnusedElements

### DIFF
--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -163,6 +163,33 @@ Remove.bufferView = function(gltf, bufferViewId) {
             });
         });
     }
+
+    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+        const extension = gltf.extensions.EXT_feature_metadata;
+        const featureTables = extension.featureTables;
+        for (const featureTableId in featureTables) {
+            if (featureTables.hasOwnProperty(featureTableId)) {
+                const featureTable = featureTables[featureTableId];
+                const properties = featureTable.properties;
+                if (defined(properties)) {
+                    for (const propertyId in properties) {
+                        if (properties.hasOwnProperty(propertyId)) {
+                            const property = properties[propertyId];
+                            if (defined(property.bufferView) && property.bufferView > bufferViewId) {
+                                property.bufferView--;
+                            }
+                            if (defined(property.arrayOffsetBufferView) && property.arrayOffsetBufferView > bufferViewId) {
+                                property.arrayOffsetBufferView--;
+                            }
+                            if (defined(property.stringOffsetBufferView) && property.stringOffsetBufferView > bufferViewId) {
+                                property.stringOffsetBufferView--;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 };
 
 Remove.image = function(gltf, imageId) {
@@ -290,6 +317,48 @@ Remove.texture = function(gltf, textureId) {
             }
         });
     });
+
+    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+        ForEach.mesh(gltf, function(mesh) {
+            ForEach.meshPrimitive(mesh, function(primitive) {
+                const extensions = primitive.extensions;
+                if (defined(extensions) && defined(extensions.EXT_feature_metadata)) {
+                    const extension = extensions.EXT_feature_metadata;
+                    const featureIdTextures = extension.featureIdTextures;
+                    if (defined(featureIdTextures)) {
+                        const featureIdTexturesLength = featureIdTextures.length;
+                        for (let i = 0; i < featureIdTexturesLength; ++i) {
+                            const featureIdTexture = featureIdTextures[i];
+                            const textureInfo = featureIdTexture.featureIds.texture;
+                            if (textureInfo.index > textureId) {
+                                --textureInfo.index;
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        const extension = gltf.extensions.EXT_feature_metadata;
+        const featureTextures = extension.featureTextures;
+        for (const featureTextureId in featureTextures) {
+            if (featureTextures.hasOwnProperty(featureTextureId)) {
+                const featureTexture = featureTextures[featureTextureId];
+                const properties = featureTexture.properties;
+                if (defined(properties)) {
+                    for (const propertyId in properties) {
+                        if (properties.hasOwnProperty(propertyId)) {
+                            const property = properties[propertyId];
+                            const textureInfo = property.texture;
+                            if (textureInfo.index > textureId) {
+                                --textureInfo.index;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 };
 
 /**
@@ -396,6 +465,33 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
                 }
             });
         });
+    }
+
+    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+        const extension = gltf.extensions.EXT_feature_metadata;
+        const featureTables = extension.featureTables;
+        for (const featureTableId in featureTables) {
+            if (featureTables.hasOwnProperty(featureTableId)) {
+                const featureTable = featureTables[featureTableId];
+                const properties = featureTable.properties;
+                if (defined(properties)) {
+                    for (const propertyId in properties) {
+                        if (properties.hasOwnProperty(propertyId)) {
+                            const property = properties[propertyId];
+                            if (defined(property.bufferView)) {
+                                usedBufferViewIds[property.bufferView] = true;
+                            }
+                            if (defined(property.arrayOffsetBufferView)) {
+                                usedBufferViewIds[property.arrayOffsetBufferView] = true;
+                            }
+                            if (defined(property.stringOffsetBufferView)) {
+                                usedBufferViewIds[property.stringOffsetBufferView] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     return usedBufferViewIds;
@@ -507,6 +603,44 @@ getListOfElementsIdsInUse.texture = function(gltf) {
             usedTextureIds[textureId] = true;
         });
     });
+
+    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+        ForEach.mesh(gltf, function(mesh) {
+            ForEach.meshPrimitive(mesh, function(primitive) {
+                const extensions = primitive.extensions;
+                if (defined(extensions) && defined(extensions.EXT_feature_metadata)) {
+                    const extension = extensions.EXT_feature_metadata;
+                    const featureIdTextures = extension.featureIdTextures;
+                    if (defined(featureIdTextures)) {
+                        const featureIdTexturesLength = featureIdTextures.length;
+                        for (let i = 0; i < featureIdTexturesLength; ++i) {
+                            const featureIdTexture = featureIdTextures[i];
+                            const textureInfo = featureIdTexture.featureIds.texture;
+                            usedTextureIds[textureInfo.index] = true;
+                        }
+                    }
+                }
+            });
+        });
+
+        const extension = gltf.extensions.EXT_feature_metadata;
+        const featureTextures = extension.featureTextures;
+        for (const featureTextureId in featureTextures) {
+            if (featureTextures.hasOwnProperty(featureTextureId)) {
+                const featureTexture = featureTextures[featureTextureId];
+                const properties = featureTexture.properties;
+                if (defined(properties)) {
+                    for (const propertyId in properties) {
+                        if (properties.hasOwnProperty(propertyId)) {
+                            const property = properties[propertyId];
+                            const textureInfo = property.texture;
+                            usedTextureIds[textureInfo.index] = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     return usedTextureIds;
 };

--- a/specs/lib/removeUnusedElementsSpec.js
+++ b/specs/lib/removeUnusedElementsSpec.js
@@ -920,4 +920,273 @@ describe('removes unused materials, textures, images, samplers', () => {
         expect(gltf.accessors[1].name).toEqual('R');
         expect(gltf.accessors[2].name).toEqual('S');
     });
+
+    it('does not remove EXT_feature_metadata buffer views and textures', () => {
+        const gltf = {
+            asset: {
+                version: '2.0'
+            },
+            extensionsUsed: [
+                'EXT_feature_metadata'
+            ],
+            extensions: {
+                EXT_feature_metadata: {
+                    schema: {
+                        classes: {
+                            vegetation: {
+                                properties: {
+                                    vegetationDensity: {
+                                        type: 'UINT8',
+                                        normalized: true
+                                    }
+                                }
+                            },
+                            landCover: {
+                                properties: {
+                                    name: {
+                                        type: 'STRING'
+                                    },
+                                    color: {
+                                        type: 'ARRAY',
+                                        componentType: 'UINT8'
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    featureTables: {
+                        landCoverTable: {
+                            class: 'landCover',
+                            count: 256,
+                            properties: {
+                                name: {
+                                    bufferView: 4,
+                                    stringOffsetBufferView: 5
+                                },
+                                color: {
+                                    bufferView: 6,
+                                    arrayOffsetBufferView: 7
+                                }
+                            }
+                        }
+                    },
+                    featureTextures: {
+                        vegetationTexture: {
+                            class: 'vegetation',
+                            properties: {
+                                vegetationDensity: {
+                                    texture: {
+                                        index: 1,
+                                        texCoord: 0
+                                    },
+                                    channels: 'r'
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            scene: 0,
+            scenes: [
+                {
+                    nodes: [
+                        0
+                    ]
+                }
+            ],
+            nodes: [
+                {
+                    mesh: 0
+                }
+            ],
+            materials: [
+                {
+                    doubleSided: true,
+                    name: 'Photogrammetry',
+                    pbrMetallicRoughness: {
+                        baseColorTexture: {
+                            index: 0,
+                            texCoord: 1
+                        },
+                        metallicFactor: 0,
+                        roughnessFactor: 0.5
+                    }
+                }
+            ],
+            meshes: [
+                {
+                    primitives: [
+                        {
+                            attributes: {
+                                POSITION: 0,
+                                TEXCOORD_0: 1,
+                                TEXCOORD_1: 2
+                            },
+                            indices: 3,
+                            material: 0,
+                            extensions: {
+                                EXT_feature_metadata: {
+                                    featureIdTextures: [
+                                        {
+                                            featureTable: 'landCoverTable',
+                                            featureIds: {
+                                                texture: {
+                                                    texCoord: 0,
+                                                    index: 2
+                                                },
+                                                channels: 'r'
+                                            }
+                                        }
+                                    ],
+                                    featureTextures: [
+                                        'vegetationTexture'
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            textures: [
+                {
+                    name: 'Photogrammetry Texture',
+                    source: 0
+                },
+                {
+                    name: 'Vegetation Texture',
+                    source: 1
+                },
+                {
+                    name: 'Land Cover Texture',
+                    source: 2
+                }
+            ],
+            images: [
+                {
+                    name: 'Photogrammetry',
+                    uri: 'photogrammetry.jpg'
+                },
+                {
+                    name: 'Vegetation',
+                    uri: 'vegetation.jpg'
+                },
+                {
+                    name: 'Land Cover',
+                    uri: 'land-cover.png'
+                }
+            ],
+            accessors: [
+                {
+                    name: 'Positions',
+                    bufferView: 0,
+                    componentType: 5126,
+                    count: 1830,
+                    max: [
+                        50.01457214355469,
+                        19.920944213867188,
+                        50.0020866394043
+                    ],
+                    min: [
+                        -50.00897979736328,
+                        -16.473196029663086,
+                        -50.006893157958984
+                    ],
+                    type: 'VEC3'
+                },
+                {
+                    name: 'Ortho UVs',
+                    bufferView: 1,
+                    componentType: 5126,
+                    count: 1830,
+                    type: 'VEC2'
+                },
+                {
+                    name: 'Photogrammetry UVs',
+                    bufferView: 2,
+                    componentType: 5126,
+                    count: 1830,
+                    type: 'VEC2'
+                },
+                {
+                    name: 'Indices',
+                    bufferView: 3,
+                    componentType: 5123,
+                    count: 5964,
+                    type: 'SCALAR'
+                }
+            ],
+            bufferViews: [
+                {
+                    name: 'Positions',
+                    buffer: 0,
+                    byteLength: 21960,
+                    byteOffset: 0
+                },
+                {
+                    name: 'Ortho UVs',
+                    buffer: 0,
+                    byteLength: 14640,
+                    byteOffset: 21960
+                },
+                {
+                    name: 'Photogrammetry UVs',
+                    buffer: 0,
+                    byteLength: 14640,
+                    byteOffset: 36600
+                },
+                {
+                    name: 'Indices',
+                    buffer: 0,
+                    byteLength: 11928,
+                    byteOffset: 51240
+                },
+                {
+                    name: 'Land Cover Name',
+                    buffer: 1,
+                    byteLength: 1546,
+                    byteOffset: 768
+                },
+                {
+                    name: 'Land Cover String Offsets',
+                    buffer: 1,
+                    byteLength: 1028,
+                    byteOffset: 2320
+                },
+                {
+                    name: 'Land Cover Color',
+                    buffer: 1,
+                    byteLength: 768,
+                    byteOffset: 0
+                },
+                {
+                    name: 'Land Cover Color Offsets',
+                    buffer: 1,
+                    byteLength: 1028,
+                    byteOffset: 3352
+                }
+            ],
+            buffers: [
+                {
+                    name: 'Geometry Buffer',
+                    byteLength: 63168,
+                    uri: 'microcosm.bin'
+                },
+                {
+                    name: 'Metadata Buffer',
+                    byteLength: 4384,
+                    uri: 'microcosm-metadata.bin'
+                }
+            ]
+        };
+
+        // Delete parts of the glTF that are not related to EXT_feature_metadata
+        delete gltf.meshes[0].primitives[0].attributes.POSITION;
+        delete gltf.materials[0].pbrMetallicRoughness.baseColorTexture;
+
+        removeUnusedElements(gltf, ['accessor', 'bufferView', 'texture', 'image']);
+
+        expect(gltf.bufferViews.length).toBe(7);
+        expect(gltf.textures.length).toBe(2);
+        expect(gltf.images.length).toBe(2);
+    });
 });


### PR DESCRIPTION
Prevents `removeUnusedElements` from deleting buffer views and textures used by [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0)