### PR TITLE
rename hasExtension -> usesExtension to avoid confusion in CesiumJS

### DIFF
--- a/lib/ForEach.js
+++ b/lib/ForEach.js
@@ -1,6 +1,6 @@
 'use strict';
 const Cesium = require('cesium');
-const hasExtension = require('./hasExtension');
+const usesExtension = require('./usesExtension');
 
 const defined = Cesium.defined;
 
@@ -304,7 +304,7 @@ ForEach.nodeInScene = function(gltf, scene, handler) {
 };
 
 ForEach.program = function(gltf, handler) {
-    if (hasExtension(gltf, 'KHR_techniques_webgl')) {
+    if (usesExtension(gltf, 'KHR_techniques_webgl')) {
         return ForEach.object(gltf.extensions.KHR_techniques_webgl.programs, handler);
     }
 
@@ -320,7 +320,7 @@ ForEach.scene = function(gltf, handler) {
 };
 
 ForEach.shader = function(gltf, handler) {
-    if (hasExtension(gltf, 'KHR_techniques_webgl')) {
+    if (usesExtension(gltf, 'KHR_techniques_webgl')) {
         return ForEach.object(gltf.extensions.KHR_techniques_webgl.shaders, handler);
     }
 
@@ -386,7 +386,7 @@ ForEach.techniqueParameter = function(technique, handler) {
 };
 
 ForEach.technique = function(gltf, handler) {
-    if (hasExtension(gltf, 'KHR_techniques_webgl')) {
+    if (usesExtension(gltf, 'KHR_techniques_webgl')) {
         return ForEach.object(gltf.extensions.KHR_techniques_webgl.techniques, handler);
     }
 

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -2,7 +2,7 @@
 const Cesium = require('cesium');
 const ForEach = require('./ForEach');
 const forEachTextureInMaterial = require('./forEachTextureInMaterial');
-const hasExtension = require('./hasExtension');
+const usesExtension = require('./usesExtension');
 
 const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
@@ -151,7 +151,7 @@ Remove.bufferView = function(gltf, bufferViewId) {
         }
     });
 
-    if (hasExtension(gltf, 'KHR_draco_mesh_compression')) {
+    if (usesExtension(gltf, 'KHR_draco_mesh_compression')) {
         ForEach.mesh(gltf, function(mesh) {
             ForEach.meshPrimitive(mesh, function(primitive) {
                 if (defined(primitive.extensions) &&
@@ -164,7 +164,7 @@ Remove.bufferView = function(gltf, bufferViewId) {
         });
     }
 
-    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+    if (usesExtension(gltf, 'EXT_feature_metadata')) {
         const extension = gltf.extensions.EXT_feature_metadata;
         const featureTables = extension.featureTables;
         for (const featureTableId in featureTables) {
@@ -318,7 +318,7 @@ Remove.texture = function(gltf, textureId) {
         });
     });
 
-    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+    if (usesExtension(gltf, 'EXT_feature_metadata')) {
         ForEach.mesh(gltf, function(mesh) {
             ForEach.meshPrimitive(mesh, function(primitive) {
                 const extensions = primitive.extensions;
@@ -407,7 +407,7 @@ getListOfElementsIdsInUse.accessor = function(gltf) {
         });
     });
 
-    if (hasExtension(gltf, 'EXT_mesh_gpu_instancing')) {
+    if (usesExtension(gltf, 'EXT_mesh_gpu_instancing')) {
         ForEach.node(gltf, function(node) {
             if (defined(node.extensions) && defined(node.extensions.EXT_mesh_gpu_instancing)) {
                 Object.keys(node.extensions.EXT_mesh_gpu_instancing.attributes).forEach(function(key) {
@@ -456,7 +456,7 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
         }
     });
 
-    if (hasExtension(gltf, 'KHR_draco_mesh_compression')) {
+    if (usesExtension(gltf, 'KHR_draco_mesh_compression')) {
         ForEach.mesh(gltf, function(mesh) {
             ForEach.meshPrimitive(mesh, function(primitive) {
                 if (defined(primitive.extensions) &&
@@ -467,7 +467,7 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
         });
     }
 
-    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+    if (usesExtension(gltf, 'EXT_feature_metadata')) {
         const extension = gltf.extensions.EXT_feature_metadata;
         const featureTables = extension.featureTables;
         for (const featureTableId in featureTables) {
@@ -604,7 +604,7 @@ getListOfElementsIdsInUse.texture = function(gltf) {
         });
     });
 
-    if (hasExtension(gltf, 'EXT_feature_metadata')) {
+    if (usesExtension(gltf, 'EXT_feature_metadata')) {
         ForEach.mesh(gltf, function(mesh) {
             ForEach.meshPrimitive(mesh, function(primitive) {
                 const extensions = primitive.extensions;

--- a/lib/usesExtension.js
+++ b/lib/usesExtension.js
@@ -3,17 +3,17 @@ const Cesium = require('cesium');
 
 const defined = Cesium.defined;
 
-module.exports = hasExtension;
+module.exports = usesExtension;
 
 /**
- * Checks whether the glTF has the given extension.
+ * Checks whether the glTF uses the given extension.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
  * @param {String} extension The name of the extension.
- * @returns {Boolean} Whether the glTF has the given extension.
+ * @returns {Boolean} Whether the glTF uses the given extension.
  *
  * @private
  */
-function hasExtension(gltf, extension) {
+function usesExtension(gltf, extension) {
     return defined(gltf.extensionsUsed) && (gltf.extensionsUsed.indexOf(extension) >= 0);
 }

--- a/specs/lib/hasExtensionSpec.js
+++ b/specs/lib/hasExtensionSpec.js
@@ -2,7 +2,7 @@
 const usesExtension = require('../../lib/usesExtension');
 
 describe('usesExtension', () => {
-    it('has extension', () => {
+    it('uses extension', () => {
         const gltf = {
             extensionsUsed: [
                 'extension1',

--- a/specs/lib/hasExtensionSpec.js
+++ b/specs/lib/hasExtensionSpec.js
@@ -1,7 +1,7 @@
 'use strict';
-const hasExtension = require('../../lib/hasExtension');
+const usesExtension = require('../../lib/usesExtension');
 
-describe('hasExtension', () => {
+describe('usesExtension', () => {
     it('has extension', () => {
         const gltf = {
             extensionsUsed: [
@@ -9,11 +9,11 @@ describe('hasExtension', () => {
                 'extension2'
             ]
         };
-        expect(hasExtension(gltf, 'extension1')).toBe(true);
-        expect(hasExtension(gltf, 'extension2')).toBe(true);
-        expect(hasExtension(gltf, 'extension3')).toBe(false);
+        expect(usesExtension(gltf, 'extension1')).toBe(true);
+        expect(usesExtension(gltf, 'extension2')).toBe(true);
+        expect(usesExtension(gltf, 'extension3')).toBe(false);
 
         const emptyGltf = {};
-        expect(hasExtension(emptyGltf, 'extension1')).toBe(false);
+        expect(usesExtension(emptyGltf, 'extension1')).toBe(false);
     });
 });

--- a/specs/lib/processGltfSpec.js
+++ b/specs/lib/processGltfSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 const fsExtra = require('fs-extra');
 const path = require('path');
-const hasExtension = require('../../lib/hasExtension');
+const usesExtension = require('../../lib/usesExtension');
 const processGltf = require('../../lib/processGltf');
 
 const gltfPath = 'specs/data/2.0/box-techniques-embedded/box-techniques-embedded.gltf';
@@ -89,7 +89,7 @@ describe('processGltf', () => {
             }
         };
         const results = await processGltf(gltf, options);
-        expect(hasExtension(results.gltf, 'KHR_draco_mesh_compression')).toBe(true);
+        expect(usesExtension(results.gltf, 'KHR_draco_mesh_compression')).toBe(true);
     });
 
     it('runs custom stages', async () => {


### PR DESCRIPTION
In CesiumJS, we want to have a `hasExtension` function to check for extensions in 3D Tiles as well as glTF. This could get confused with the gltf-pipeline version, so we are renaming this.

This is based on this PR comment in cesium: https://github.com/CesiumGS/cesium/pull/9595#discussion_r651400226

@sanjeetsuhag @lilleyse 