### PR TITLE
Align glTF chunks and bufferViews to 8-bytes

### DIFF
--- a/lib/getBufferPadded.js
+++ b/lib/getBufferPadded.js
@@ -2,7 +2,9 @@
 module.exports = getBufferPadded;
 
 /**
- * Pad the buffer to the next 4-byte boundary to ensure proper alignment for the section that follows.
+ * Pad the buffer to the next 8-byte boundary to ensure proper alignment for the section that follows.
+ * glTF only requires 4-byte alignment but some extensions like EXT_feature_metadata require 8-byte
+ * alignment for buffer views.
  *
  * @param {Buffer} buffer The buffer.
  * @returns {Buffer} The padded buffer.
@@ -10,7 +12,7 @@ module.exports = getBufferPadded;
  * @private
  */
 function getBufferPadded(buffer) {
-    const boundary = 4;
+    const boundary = 8;
     const byteLength = buffer.length;
     const remainder = byteLength % boundary;
     if (remainder === 0) {

--- a/lib/getJsonBufferPadded.js
+++ b/lib/getJsonBufferPadded.js
@@ -4,8 +4,10 @@ module.exports = getJsonBufferPadded;
 /**
  * Convert the JSON object to a padded buffer.
  *
- * Pad the JSON with extra whitespace to fit the next 4-byte boundary. This ensures proper alignment
- * for the section that follows.
+ * Pad the JSON with extra whitespace to fit the next 8-byte boundary. This ensures proper alignment
+ * for the section that follows. glTF only requires 4-byte alignment but some extensions like
+ * EXT_feature_metadata require 8-byte alignment for buffer views.
+
  *
  * @param {Object} [json] The JSON object.
  * @returns {Buffer} The padded JSON buffer.
@@ -15,7 +17,7 @@ module.exports = getJsonBufferPadded;
 function getJsonBufferPadded(json) {
     let string = JSON.stringify(json);
 
-    const boundary = 4;
+    const boundary = 8;
     const byteLength = Buffer.byteLength(string);
     const remainder = byteLength % boundary;
     const padding = (remainder === 0) ? 0 : boundary - remainder;

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -157,10 +157,11 @@ function forEachBufferViewLikeObject(gltf, callback) {
 }
 
 function allocateBufferPadding(byteLength) {
-    const alignment = byteLength & 3;
-    if (alignment > 0) {
-        const bytesToPad = 4 - alignment;
-        return Buffer.alloc(bytesToPad);
+    const boundary = 8;
+    const remainder = byteLength % boundary;
+    const padding = (remainder === 0) ? 0 : boundary - remainder;
+    if (padding > 0) {
+        return Buffer.alloc(padding);
     }
     return undefined;
 }

--- a/specs/lib/getBufferPaddedSpec.js
+++ b/specs/lib/getBufferPaddedSpec.js
@@ -2,21 +2,25 @@
 const getBufferPadded = require('../../lib/getBufferPadded');
 
 describe('getBufferPadded', () => {
-    it('gets buffer padded to 4 bytes', () => {
+    it('gets buffer padded to 8 bytes', () => {
         let buffer = Buffer.alloc(0);
         let bufferPadded = getBufferPadded(buffer);
         expect(bufferPadded.length).toBe(0);
 
         buffer = Buffer.from([1]);
         bufferPadded = getBufferPadded(buffer);
-        expect(bufferPadded.length).toBe(4);
+        expect(bufferPadded.length).toBe(8);
         expect(bufferPadded.readUInt8(0)).toBe(1);
         expect(bufferPadded.readUInt8(1)).toBe(0);
         expect(bufferPadded.readUInt8(2)).toBe(0);
         expect(bufferPadded.readUInt8(3)).toBe(0);
+        expect(bufferPadded.readUInt8(4)).toBe(0);
+        expect(bufferPadded.readUInt8(5)).toBe(0);
+        expect(bufferPadded.readUInt8(6)).toBe(0);
+        expect(bufferPadded.readUInt8(7)).toBe(0);
 
-        // Does not allocate a new buffer when buffer length is already aligned to 4 bytes
-        buffer = Buffer.alloc(4);
+        // Does not allocate a new buffer when buffer length is already aligned to 8 bytes
+        buffer = Buffer.alloc(8);
         bufferPadded = getBufferPadded(buffer);
         expect(bufferPadded).toBe(buffer);
 

--- a/specs/lib/getJsonBufferPaddedSpec.js
+++ b/specs/lib/getJsonBufferPaddedSpec.js
@@ -2,7 +2,7 @@
 const getJsonBufferPadded = require('../../lib/getJsonBufferPadded');
 
 describe('getJsonBufferPadded', () => {
-    it('get json buffer padded to 4 bytes', () => {
+    it('get json buffer padded to 8 bytes', () => {
         const gltf = {
             asset: {
                 version: '2.0'
@@ -11,7 +11,11 @@ describe('getJsonBufferPadded', () => {
         const string = JSON.stringify(gltf);
         expect(string.length).toBe(27);
         const bufferPadded = getJsonBufferPadded(gltf);
-        expect(bufferPadded.length).toBe(28);
+        expect(bufferPadded.length).toBe(32);
         expect(bufferPadded.readUInt8(27)).toBe(32); // Space
+        expect(bufferPadded.readUInt8(28)).toBe(32);
+        expect(bufferPadded.readUInt8(29)).toBe(32);
+        expect(bufferPadded.readUInt8(30)).toBe(32);
+        expect(bufferPadded.readUInt8(31)).toBe(32);
     });
 });

--- a/specs/lib/gltfToGlbSpec.js
+++ b/specs/lib/gltfToGlbSpec.js
@@ -77,7 +77,7 @@ describe('gltfToGlb', () => {
         const meshoptObject1 = bufferView1.extensions.EXT_meshopt_compression;
         const meshoptObject2 = bufferView2.extensions.EXT_meshopt_compression;
 
-        expect(buffer0.byteLength).toBe(1428);
+        expect(buffer0.byteLength).toBe(1432);
         expect(buffer0.uri).not.toBeDefined();
 
         expect(bufferView0.buffer).toBe(0);
@@ -88,17 +88,17 @@ describe('gltfToGlb', () => {
         expect(meshoptObject0.byteLength).toBe(265);
 
         expect(bufferView1.buffer).toBe(0);
-        expect(bufferView1.byteOffset).toBe(668);
+        expect(bufferView1.byteOffset).toBe(672);
         expect(bufferView1.byteLength).toBe(200);
         expect(meshoptObject1.buffer).toBe(0);
-        expect(meshoptObject1.byteOffset).toBe(868);
+        expect(meshoptObject1.byteOffset).toBe(872);
         expect(meshoptObject1.byteLength).toBe(117);
 
         expect(bufferView2.buffer).toBe(0);
-        expect(bufferView2.byteOffset).toBe(988);
+        expect(bufferView2.byteOffset).toBe(992);
         expect(bufferView2.byteLength).toBe(360);
         expect(meshoptObject2.buffer).toBe(0);
-        expect(meshoptObject2.byteOffset).toBe(1348);
+        expect(meshoptObject2.byteOffset).toBe(1352);
         expect(meshoptObject2.byteLength).toBe(78);
     });
 
@@ -129,7 +129,7 @@ describe('gltfToGlb', () => {
 
         expect(buffer0.byteLength).toBe(960);
         expect(buffer0.uri).toBe('meshopt-fallback-meshopt-fallback-1.bin');
-        expect(buffer1.byteLength).toBe(468);
+        expect(buffer1.byteLength).toBe(472);
         expect(buffer1.uri).toBe('meshopt-fallback.bin');
 
         expect(bufferView0.buffer).toBe(0);
@@ -143,14 +143,14 @@ describe('gltfToGlb', () => {
         expect(bufferView1.byteOffset).toBe(400);
         expect(bufferView1.byteLength).toBe(200);
         expect(meshoptObject1.buffer).toBe(1);
-        expect(meshoptObject1.byteOffset).toBe(268);
+        expect(meshoptObject1.byteOffset).toBe(272);
         expect(meshoptObject1.byteLength).toBe(117);
 
         expect(bufferView2.buffer).toBe(0);
         expect(bufferView2.byteOffset).toBe(600);
         expect(bufferView2.byteLength).toBe(360);
         expect(meshoptObject2.buffer).toBe(1);
-        expect(meshoptObject2.byteOffset).toBe(388);
+        expect(meshoptObject2.byteOffset).toBe(392);
         expect(meshoptObject2.byteLength).toBe(78);
     });
 });

--- a/specs/lib/mergeBuffersSpec.js
+++ b/specs/lib/mergeBuffersSpec.js
@@ -10,8 +10,8 @@ describe('mergeBuffers', () => {
         const dataUri0 = 'data:application/octet-stream;base64,' + buffer0.toString('base64');
         const dataUri1 = 'data:application/octet-stream;base64,' + buffer1.toString('base64');
 
-        // All buffer views start on 4-byte alignment, the buffer ends on a 4-byte alignment, and extraneous buffer data is removed
-        const expectedBuffer = Buffer.from((new Uint8Array([1, 1, 1, 0, 2, 2, 0, 0, 3, 3, 3, 0, 4, 4, 4, 4, 4, 0, 0, 0])));
+        // All buffer views start on 8-byte alignment, the buffer ends on a 8-byte alignment, and extraneous buffer data is removed
+        const expectedBuffer = Buffer.from((new Uint8Array([1, 1, 1, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 3, 3, 3, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 0, 0, 0])));
 
         const gltf = {
             bufferViews: [
@@ -69,10 +69,10 @@ describe('mergeBuffers', () => {
         const dataUri4 = 'data:application/octet-stream;base64,' + buffer4.toString('base64');
         const dataUri5 = 'data:application/octet-stream;base64,' + buffer5.toString('base64');
 
-        // All buffer views start on 4-byte alignment, the buffer ends on a 4-byte alignment, and extraneous buffer data is removed
-        const expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1, 2, 2, 2, 2])));
-        const expectedBuffer1 = Buffer.from((new Uint8Array([3, 0, 0, 0, 4, 4, 4, 0])));
-        const expectedBuffer2 = Buffer.from((new Uint8Array([5, 5, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])));
+        // All buffer views start on 8-byte alignment, the buffer ends on a 8-byte alignment, and extraneous buffer data is removed
+        const expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1, 0, 0, 0, 0, 2, 2, 2, 2, 0, 0, 0, 0])));
+        const expectedBuffer1 = Buffer.from((new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 0, 0, 0, 0, 0])));
+        const expectedBuffer2 = Buffer.from((new Uint8Array([5, 5, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0])));
 
         const gltf = {
             bufferViews: [
@@ -173,14 +173,14 @@ describe('mergeBuffers', () => {
         const dataUri4 = 'data:application/octet-stream;base64,' + buffer4.toString('base64');
         const dataUri5 = 'data:application/octet-stream;base64,' + buffer5.toString('base64');
 
-        // All buffer views start on 4-byte alignment, the buffer ends on a 4-byte alignment, and extraneous buffer data is removed
-        const expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1])));
-        const expectedBuffer1 = Buffer.from((new Uint8Array([2, 2, 2, 2])));
-        const expectedBuffer2 = Buffer.from((new Uint8Array([3, 0, 0, 0])));
-        const expectedBuffer3 = Buffer.from((new Uint8Array([5, 5, 0, 0])));
-        const expectedBuffer4 = Buffer.from((new Uint8Array([4, 4, 4, 0])));
-        const expectedBuffer5 = Buffer.from((new Uint8Array([6, 0, 0, 0])));
-        const expectedBuffer6 = Buffer.from((new Uint8Array([7, 0, 0, 0])));
+        // All buffer views start on 8-byte alignment, the buffer ends on a 8-byte alignment, and extraneous buffer data is removed
+        const expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1, 0, 0, 0, 0])));
+        const expectedBuffer1 = Buffer.from((new Uint8Array([2, 2, 2, 2, 0, 0, 0, 0])));
+        const expectedBuffer2 = Buffer.from((new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0])));
+        const expectedBuffer3 = Buffer.from((new Uint8Array([5, 5, 0, 0, 0, 0, 0, 0])));
+        const expectedBuffer4 = Buffer.from((new Uint8Array([4, 4, 4, 0, 0, 0, 0, 0])));
+        const expectedBuffer5 = Buffer.from((new Uint8Array([6, 0, 0, 0, 0, 0, 0, 0])));
+        const expectedBuffer6 = Buffer.from((new Uint8Array([7, 0, 0, 0, 0, 0, 0, 0])));
 
         const gltf = {
             bufferViews: [

--- a/specs/lib/processGltfSpec.js
+++ b/specs/lib/processGltfSpec.js
@@ -172,7 +172,7 @@ describe('processGltf', () => {
 
         expect(buffer0.byteLength).toBe(960);
         expect(buffer0.uri).toBeDefined();
-        expect(buffer1.byteLength).toBe(468);
+        expect(buffer1.byteLength).toBe(472);
         expect(buffer1.uri).toBeDefined();
 
         expect(bufferView0.buffer).toBe(0);
@@ -186,14 +186,14 @@ describe('processGltf', () => {
         expect(bufferView1.byteOffset).toBe(400);
         expect(bufferView1.byteLength).toBe(200);
         expect(meshoptObject1.buffer).toBe(1);
-        expect(meshoptObject1.byteOffset).toBe(268);
+        expect(meshoptObject1.byteOffset).toBe(272);
         expect(meshoptObject1.byteLength).toBe(117);
 
         expect(bufferView2.buffer).toBe(0);
         expect(bufferView2.byteOffset).toBe(600);
         expect(bufferView2.byteLength).toBe(360);
         expect(meshoptObject2.buffer).toBe(1);
-        expect(meshoptObject2.byteOffset).toBe(388);
+        expect(meshoptObject2.byteOffset).toBe(392);
         expect(meshoptObject2.byteLength).toBe(78);
     });
 
@@ -219,7 +219,7 @@ describe('processGltf', () => {
         const meshoptObject1 = bufferView1.extensions.EXT_meshopt_compression;
         const meshoptObject2 = bufferView2.extensions.EXT_meshopt_compression;
 
-        expect(buffer0.byteLength).toBe(468);
+        expect(buffer0.byteLength).toBe(472);
         expect(buffer0.uri).toBeDefined();
         expect(buffer1.byteLength).toBe(960);
         expect(buffer1.uri).not.toBeDefined();
@@ -235,14 +235,14 @@ describe('processGltf', () => {
         expect(bufferView1.byteOffset).toBe(400);
         expect(bufferView1.byteLength).toBe(200);
         expect(meshoptObject1.buffer).toBe(0);
-        expect(meshoptObject1.byteOffset).toBe(268);
+        expect(meshoptObject1.byteOffset).toBe(272);
         expect(meshoptObject1.byteLength).toBe(117);
 
         expect(bufferView2.buffer).toBe(1);
         expect(bufferView2.byteOffset).toBe(600);
         expect(bufferView2.byteLength).toBe(360);
         expect(meshoptObject2.buffer).toBe(0);
-        expect(meshoptObject2.byteOffset).toBe(388);
+        expect(meshoptObject2.byteOffset).toBe(392);
         expect(meshoptObject2.byteLength).toBe(78);
     });
 });


### PR DESCRIPTION
The [EXT_feature_metadata](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0) spec requires that all buffer views in a feature table are aligned to 8-bytes, mainly to accommodate the `FLOAT64`, `UINT64`, and `INT64` types. If the buffer view's `buffer` is the GLB-stored `BIN` chunk the byte offset is measured relative to the beginning of the GLB. Otherwise, it is measured relative to the beginning of the buffer.

Sometimes these files are passed through gltf-pipeline and byte alignment isn't handled properly. This can happen if feature table tables are stored externally and then combined into a glb.

The easiest thing to do was to change gltf-pipeline to use 8-byte alignment for the JSON chunk, binary chunk, and buffer views. This is still conformant with the glTF spec which requires that the start and end of each chunk (JSON chunk and binary chunk) are aligned to 4-bytes, vertex attributes are aligned to 4-bytes, and other accessors are aligned to their component type. The only change now is a bit of extra padding.