### PR TITLE
Fix doc for glbToGltf, gltfToGlb, processGlb, processGltf

### DIFF
--- a/lib/glbToGltf.js
+++ b/lib/glbToGltf.js
@@ -9,7 +9,7 @@ module.exports = glbToGltf;
  *
  * @param {Buffer} glb A buffer containing the glb contents.
  * @param {Object} [options] The same options object as {@link processGltf}
- * @returns {Promise} A promise that resolves to an object containing a glTF asset.
+ * @returns {Promise} A promise that resolves to an object containing the glTF and a dictionary containing separate resources.
  */
 function glbToGltf(glb, options) {
     const gltf = parseGlb(glb);

--- a/lib/gltfToGlb.js
+++ b/lib/gltfToGlb.js
@@ -13,7 +13,7 @@ module.exports = gltfToGlb;
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
  * @param {Object} [options] The same options object as {@link processGltf}
- * @returns {Promise} A promise that resolves to a buffer containing the glb contents.
+ * @returns {Promise} A promise that resolves to an object containing the glb and a dictionary containing separate resources.
  */
 function gltfToGlb(gltf, options) {
     options = defined(options) ? clone(options) : {};

--- a/lib/processGlb.js
+++ b/lib/processGlb.js
@@ -9,7 +9,7 @@ module.exports = processGlb;
  *
  * @param {Buffer} glb A buffer containing the glb contents.
  * @param {Object} [options] The same options object as {@link processGltf}
- * @returns {Promise} A promise that resolves to a buffer containing the glb contents.
+ * @returns {Promise} A promise that resolves to an object containing the glb and a dictionary containing separate resources.
  */
 function processGlb(glb, options) {
     const gltf = parseGlb(glb);

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -32,7 +32,7 @@ module.exports = processGltf;
  * @param {Stage[]} [options.customStages] Custom stages to run on the glTF asset.
  * @param {Logger} [options.logger] A callback function for handling logged messages. Defaults to console.log.
  *
- * @returns {Promise} A promise that resolves to the processed glTF and a dictionary containing separate resources.
+ * @returns {Promise} A promise that resolves to an object containing the glTF and a dictionary containing separate resources.
  */
 function processGltf(gltf, options) {
     const defaults = processGltf.defaults;


### PR DESCRIPTION
Only `processGltf` mentioned that the resolved object contains a dictionary containing separate resources. This fixes the other functions `glbToGltf`, `gltfToGlb`, and `processGlb`.