### PR TITLE
Switch to prettier for formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "cesium/node",
+  "extends": ["cesium/node", "prettier"],
   "rules": {
     "no-unused-vars": ["error", {"args": "none"}]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ package-lock.json
 .idea/workspace.xml
 .idea/tasks.xml
 
-# VS Code user-specific
+# VSCode user-specific
 .vscode
 
 # Generate data

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+/.vscode
 /.idea
 /dist
 /coverage
@@ -12,9 +13,9 @@
 .gitattributes
 .nyc_output
 .npmignore
+.prettierignore
 .travis.yml
 .appveyor.yml
 gulpfile.js
 *.tgz
 !doc/gltf.png
-.vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# Ignore everything
+*
+
+# Unignore directories (to all depths) and unignore code in these directories
+!bin/**/
+!doc/**/
+!lib/**/
+!specs/**/
+
+!**/*.js
+!**/*.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
 
 script:
   - npm run eslint
+  - npm run prettier-check
   - npm run test -- --failTaskOnError --suppressPassed;
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
 
 script:
   - npm run eslint
-  - npm run prettier-check
   - npm run test -- --failTaskOnError --suppressPassed;
 
 after_success:

--- a/package.json
+++ b/package.json
@@ -51,11 +51,6 @@
     "prettier": "2.3.2",
     "pretty-quick": "^3.1.1"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "eslint && pretty-quick --staged"
-    }
-  },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "eslint": "eslint \"./**/*.js\" --cache --quiet",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,23 @@
     "cloc": "^2.8.0",
     "coveralls": "^3.1.1",
     "dependency-tree": "^8.1.1",
-    "eslint": "^7.31.0",
+    "eslint": "^7.32.0",
     "eslint-config-cesium": "^8.0.1",
+    "eslint-config-prettier": "^8.3.0",
     "gulp": "^4.0.2",
+    "husky": "^4.3.8",
     "jasmine": "^3.8.0",
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^3.6.7",
     "nyc": "^15.1.0",
-    "open": "^8.2.1"
+    "open": "^8.2.1",
+    "prettier": "2.3.2",
+    "pretty-quick": "^3.1.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "eslint && pretty-quick --staged"
+    }
   },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
@@ -56,6 +65,9 @@
     "coverage": "gulp coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "cloc": "gulp cloc",
+    "prettier": "prettier --write \"**/*\"",
+    "prettier-check": "prettier --check \"**/*\"",
+    "pretty-quick": "pretty-quick",
     "build-cesium": "gulp build-cesium"
   },
   "bin": {


### PR DESCRIPTION
- Follows the same conventions as CesiumJS.
- Doesn't actually run the formatter or install the pre-commit hook yet.
- The changes can be viewed here: https://github.com/CesiumGS/gltf-pipeline/compare/prettier-test?expand=1

Steps for migrating to prettier will be as follows:
  1. Merge this into main
  1. Add a `pre-prettier` tag
  1. Actually run prettier and commit the code changes to main
  1. Add a `post-prettier` tag
  1. Open a follow-up PR to add the pre-commit hooks for running prettier

Recommendations for how to update your branches can be found here: https://community.cesium.com/t/cesiumjs-source-code-is-now-formatted-with-prettier/9362