### PR TITLE
Add ThirdParty.json

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "bluebird",
+    "license": [
+      "MIT"
+    ],
+    "version": "3.7.2",
+    "url": "https://www.npmjs.com/package/bluebird"
+  },
+  {
+    "name": "cesium",
+    "license": [
+      "Apache-2.0"
+    ],
+    "version": "1.93.0",
+    "url": "https://www.npmjs.com/package/cesium"
+  },
+  {
+    "name": "draco3d",
+    "license": [
+      "Apache-2.0"
+    ],
+    "version": "1.5.2",
+    "url": "https://www.npmjs.com/package/draco3d"
+  },
+  {
+    "name": "fs-extra",
+    "license": [
+      "MIT"
+    ],
+    "version": "10.1.0",
+    "url": "https://www.npmjs.com/package/fs-extra"
+  },
+  {
+    "name": "mime",
+    "license": [
+      "MIT"
+    ],
+    "version": "2.6.0",
+    "url": "https://www.npmjs.com/package/mime"
+  },
+  {
+    "name": "object-hash",
+    "license": [
+      "MIT"
+    ],
+    "version": "2.2.0",
+    "url": "https://www.npmjs.com/package/object-hash"
+  },
+  {
+    "name": "yargs",
+    "license": [
+      "MIT"
+    ],
+    "version": "17.4.1",
+    "url": "https://www.npmjs.com/package/yargs"
+  }
+]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ const path = require("path");
 const Promise = require("bluebird");
 const yargs = require("yargs");
 
+const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const argv = yargs.argv;
 
@@ -36,6 +37,7 @@ module.exports = {
   "test-watch": testWatch,
   coverage: coverage,
   cloc: cloc,
+  "generate-third-party": generateThirdParty,
 };
 
 function test(done) {
@@ -276,4 +278,88 @@ function buildCesium() {
       });
     });
   });
+}
+
+function getLicenseDataFromPackage(packageName, override) {
+  override = defaultValue(override, defaultValue.EMPTY_OBJECT);
+  const packagePath = path.join("node_modules", packageName, "package.json");
+
+  if (!fsExtra.existsSync(packagePath)) {
+    throw new Error(`Unable to find ${packageName} license information`);
+  }
+
+  const contents = fsExtra.readFileSync(packagePath);
+  const packageJson = JSON.parse(contents);
+
+  let licenseField = override.license;
+
+  if (!licenseField) {
+    licenseField = [packageJson.license];
+  }
+
+  if (!licenseField && packageJson.licenses) {
+    licenseField = packageJson.licenses;
+  }
+
+  if (!licenseField) {
+    console.log(`No license found for ${packageName}`);
+    licenseField = ["NONE"];
+  }
+
+  let version = packageJson.version;
+  if (!packageJson.version) {
+    console.log(`No version information found for ${packageName}`);
+    version = "NONE";
+  }
+
+  return {
+    name: packageName,
+    license: licenseField,
+    version: version,
+    url: `https://www.npmjs.com/package/${packageName}`,
+    notes: override.notes,
+  };
+}
+
+function readThirdPartyExtraJson() {
+  const path = "ThirdParty.extra.json";
+  if (fsExtra.existsSync(path)) {
+    const contents = fsExtra.readFileSync(path);
+    return JSON.parse(contents);
+  }
+  return [];
+}
+
+async function generateThirdParty() {
+  const packageJson = JSON.parse(fsExtra.readFileSync("package.json"));
+  const thirdPartyExtraJson = readThirdPartyExtraJson();
+
+  const thirdPartyJson = [];
+
+  const dependencies = packageJson.dependencies;
+  for (const packageName in dependencies) {
+    if (dependencies.hasOwnProperty(packageName)) {
+      const override = thirdPartyExtraJson.find(
+        (entry) => entry.name === packageName
+      );
+      thirdPartyJson.push(getLicenseDataFromPackage(packageName, override));
+    }
+  }
+
+  thirdPartyJson.sort(function (a, b) {
+    const nameA = a.name.toLowerCase();
+    const nameB = b.name.toLowerCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  fsExtra.writeFileSync(
+    "ThirdParty.json",
+    JSON.stringify(thirdPartyJson, null, 2)
+  );
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "prettier": "prettier --write \"**/*\"",
     "prettier-check": "prettier --check \"**/*\"",
     "pretty-quick": "pretty-quick",
-    "build-cesium": "gulp build-cesium"
+    "build-cesium": "gulp build-cesium",
+    "generate-third-party": "gulp generate-third-party"
   },
   "bin": {
     "gltf-pipeline": "./bin/gltf-pipeline.js"


### PR DESCRIPTION
Adds `ThirdParty.json` for tracking third party dependencies. To regenerate the file run `npm run generate-third-party`.

CC @shehzan10 