### PR TITLE
Use JavaScript Array.fill in place of Cesium.arrayFill

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Next release
 
 - Fixed handling of glTF models with the [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) extension.
+- Replaced the Cesium.arrayFill polyfill with calls to the native JavaScript method Array.fill. See the [related PR in CesiumJS](https://github.com/CesiumGS/cesium/pull/10488).
 
 ### 3.0.4 - 2021-08-02
 

--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -14,7 +14,6 @@ const removeUnusedElements = require("./removeUnusedElements");
 const replaceWithDecompressedPrimitive = require("./replaceWithDecompressedPrimitive");
 const splitPrimitives = require("./splitPrimitives");
 
-const arrayFill = Cesium.arrayFill;
 const Cartesian3 = Cesium.Cartesian3;
 const Check = Cesium.Check;
 const clone = Cesium.clone;
@@ -118,8 +117,8 @@ function compress(gltf, options, encoderModule, decoderModule) {
   } else if (unifiedQuantization) {
     // Collect bounding box from all primitives. Currently works only for vec3 positions (XYZ).
     const accessors = gltf.accessors;
-    const min = arrayFill(new Array(3), Number.POSITIVE_INFINITY);
-    const max = arrayFill(new Array(3), Number.NEGATIVE_INFINITY);
+    const min = new Array(3).fill(Number.POSITIVE_INFINITY);
+    const max = new Array(3).fill(Number.NEGATIVE_INFINITY);
     ForEach.accessorWithSemantic(gltf, "POSITION", function (accessorId) {
       const accessor = accessors[accessorId];
       if (accessor.type !== "VEC3") {

--- a/lib/findAccessorMinMax.js
+++ b/lib/findAccessorMinMax.js
@@ -1,7 +1,6 @@
 "use strict";
 const Cesium = require("cesium");
 
-const arrayFill = Cesium.arrayFill;
 const ComponentDatatype = Cesium.ComponentDatatype;
 const defined = Cesium.defined;
 
@@ -29,19 +28,13 @@ function findAccessorMinMax(gltf, accessor) {
   // According to the spec, when bufferView is not defined, accessor must be initialized with zeros
   if (!defined(accessor.bufferView)) {
     return {
-      min: arrayFill(new Array(numberOfComponents), 0.0),
-      max: arrayFill(new Array(numberOfComponents), 0.0),
+      min: new Array(numberOfComponents).fill(0.0),
+      max: new Array(numberOfComponents).fill(0.0),
     };
   }
 
-  const min = arrayFill(
-    new Array(numberOfComponents),
-    Number.POSITIVE_INFINITY
-  );
-  const max = arrayFill(
-    new Array(numberOfComponents),
-    Number.NEGATIVE_INFINITY
-  );
+  const min = new Array(numberOfComponents).fill(Number.POSITIVE_INFINITY);
+  const max = new Array(numberOfComponents).fill(Number.NEGATIVE_INFINITY);
 
   const bufferView = bufferViews[bufferViewId];
   const bufferId = bufferView.buffer;

--- a/lib/readAccessorPacked.js
+++ b/lib/readAccessorPacked.js
@@ -4,7 +4,6 @@ const getAccessorByteStride = require("./getAccessorByteStride");
 const getComponentReader = require("./getComponentReader");
 const numberOfComponentsForType = require("./numberOfComponentsForType");
 
-const arrayFill = Cesium.arrayFill;
 const ComponentDatatype = Cesium.ComponentDatatype;
 const defined = Cesium.defined;
 
@@ -29,8 +28,7 @@ function readAccessorPacked(gltf, accessor) {
   const values = new Array(numberOfComponents * count);
 
   if (!defined(accessor.bufferView)) {
-    arrayFill(values, 0);
-    return values;
+    return values.fill(0);
   }
 
   const bufferView = gltf.bufferViews[accessor.bufferView];

--- a/specs/lib/readAccessorPackedSpec.js
+++ b/specs/lib/readAccessorPackedSpec.js
@@ -3,8 +3,6 @@ const Cesium = require("cesium");
 const readAccessorPacked = require("../../lib/readAccessorPacked");
 const readResources = require("../../lib/readResources");
 
-const arrayFill = Cesium.arrayFill;
-
 const contiguousData = [
   -1.0, 1.0, -1.0, 0.0, 0.0, 0.0, 3.0, 2.0, 1.0, -1.0, -2.0, -3.0,
 ];
@@ -91,7 +89,7 @@ describe("readAccessorPacked", () => {
         },
       ],
     };
-    const expected = arrayFill(new Array(12), 0); // All zeroes
+    const expected = new Array(12).fill(0);
     expect(readAccessorPacked(gltf, gltf.accessors[0])).toEqual(expected);
   });
 });

--- a/specs/lib/updateAccessorComponentTypeSpec.js
+++ b/specs/lib/updateAccessorComponentTypeSpec.js
@@ -3,20 +3,16 @@ const Cesium = require("cesium");
 const readResources = require("../../lib/readResources");
 const updateAccessorComponentTypes = require("../../lib/updateAccessorComponentTypes");
 
-const arrayFill = Cesium.arrayFill;
 const WebGLConstants = Cesium.WebGLConstants;
 
 let buffer;
 
 describe("updateAccessorComponentTypes", () => {
   beforeAll(() => {
-    const byteBuffer = Buffer.from(arrayFill(new Int8Array(96), 0).buffer);
-    const floatBuffer = Buffer.from(
-      arrayFill(new Float32Array(96), 0.0).buffer
-    );
-    const unsignedShortBuffer = Buffer.from(
-      arrayFill(new Uint16Array(96), 0).buffer
-    );
+    // Note: TypedArray constructors initialize all elements to zero
+    const byteBuffer = Buffer.from(new Int8Array(96).buffer);
+    const floatBuffer = Buffer.from(new Float32Array(96).buffer);
+    const unsignedShortBuffer = Buffer.from(new Uint16Array(96).buffer);
     const source = Buffer.concat([
       byteBuffer,
       floatBuffer,

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -5,7 +5,6 @@ const numberOfComponentsForType = require("../../lib/numberOfComponentsForType")
 const readResources = require("../../lib/readResources");
 const updateVersion = require("../../lib/updateVersion");
 
-const arrayFill = Cesium.arrayFill;
 const Cartesian3 = Cesium.Cartesian3;
 const Quaternion = Cesium.Quaternion;
 const WebGLConstants = Cesium.WebGLConstants;
@@ -317,15 +316,9 @@ describe("updateVersion", () => {
     const applicationSpecificBuffer = Buffer.from(
       new Int16Array([-2, 1, 0, 1, 2, 3]).buffer
     );
-    const positionBuffer = Buffer.from(
-      arrayFill(new Float32Array(9), 1.0).buffer
-    );
-    const normalBuffer = Buffer.from(
-      arrayFill(new Float32Array(9), 2.0).buffer
-    );
-    const texcoordBuffer = Buffer.from(
-      arrayFill(new Float32Array(6), 3.0).buffer
-    );
+    const positionBuffer = Buffer.from(new Float32Array(9).fill(1.0).buffer);
+    const normalBuffer = Buffer.from(new Float32Array(9).fill(2.0).buffer);
+    const texcoordBuffer = Buffer.from(new Float32Array(6).fill(3.0).buffer);
     const source = Buffer.concat([
       applicationSpecificBuffer,
       positionBuffer,


### PR DESCRIPTION
Several library functions and tests are generating pre-filled arrays using the polyfill method Cesium.arrayFill. This polyfill is no longer needed, since the JavaScript method [Array.fill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill) is implemented on all supported platforms. See https://github.com/CesiumGS/cesium/pull/10488.

This PR removes the calls to the polyfill, and replaces them with calls to [Array.fill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill).