### PR TITLE
Fix parsing mapping with # in the file name.

### DIFF
--- a/lib/readResources.js
+++ b/lib/readResources.js
@@ -133,7 +133,7 @@ function readFile(object, uri, saveResourceId, options) {
   let absoluteUrl;
   try {
     absoluteUrl = new URL(
-      uri,
+      uri.replace("#", "%23"),
       hasResourceDirectory ? pathToFileURL(resourceDirectory) : undefined
     );
   } catch (error) {


### PR DESCRIPTION
```bash
gltf-pipeline -i model.glb -o outputs/model.gltf -t
gltf-pipeline -o model-16.glb -i outputs/model.gltf -b
```

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/30215105/187174180-9f72a037-756d-4046-b4c0-3e36719a1541.png">

Fixed the problem that when the file name of a model mapping has a "#" symbol, the content after it is parsed as URL Hash, resulting in a missing file address.