### PR TITLE
Basic CESIUM_primitive_outline support

### DIFF
--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -111,6 +111,15 @@ Remove.accessor = function (gltf, accessorId) {
       if (defined(indices) && indices > accessorId) {
         primitive.indices--;
       }
+
+      const ext = primitive.extensions;
+      if (
+        defined(ext) &&
+        defined(ext.CESIUM_primitive_outline) &&
+        ext.CESIUM_primitive_outline.indices > accessorId
+      ) {
+        --ext.CESIUM_primitive_outline.indices;
+      }
     });
   });
 
@@ -548,6 +557,24 @@ getListOfElementsIdsInUse.accessor = function (gltf) {
           }
         );
       }
+    });
+  }
+
+  if (usesExtension(gltf, "CESIUM_primitive_outline")) {
+    ForEach.mesh(gltf, function (mesh) {
+      ForEach.meshPrimitive(mesh, function (primitive) {
+        const extensions = primitive.extensions;
+        if (
+          defined(extensions) &&
+          defined(extensions.CESIUM_primitive_outline)
+        ) {
+          const extension = extensions.CESIUM_primitive_outline;
+          const indicesAccessorId = extension.indices;
+          if (defined(indicesAccessorId)) {
+            usedAccessorIds[indicesAccessorId] = true;
+          }
+        }
+      });
     });
   }
 


### PR DESCRIPTION
The `removeUnusedElements` family of functions considered the accessors that are used by `CESIUM_primitive_outline` to be "unused", and removed them. 

This PR is a small fix that causes these accessors to be preserved, and the `CESIUM_primitive_outline.indices` to be updated (no, not the accessor contents, only that accessor index). 

This is implemented in a somewhat copy-and-paste-ish style: It uses the same approach that was used for other extensions. But one could consider to generalize the approach there: Having to support each extension manually like this does not scale indefinitely....

This might fix https://github.com/CesiumGS/gltf-pipeline/issues/630 



