### PR TITLE
Set resource directory in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ npm install -g gltf-pipeline
 const gltfPipeline = require("gltf-pipeline");
 const fsExtra = require("fs-extra");
 const gltfToGlb = gltfPipeline.gltfToGlb;
-const gltf = fsExtra.readJsonSync("model.gltf");
-gltfToGlb(gltf).then(function (results) {
+const gltf = fsExtra.readJsonSync("./input/model.gltf");
+const options = { resourceDirectory: "./input/" }
+gltfToGlb(gltf, options).then(function (results) {
   fsExtra.writeFileSync("model.glb", results.glb);
 });
 ```
 
-#### Converting a glb to glTF
+#### Converting a glb to embedded glTF
 
 ```javascript
 const gltfPipeline = require("gltf-pipeline");


### PR DESCRIPTION
The example in the README.md for converting a `.gltf` file to a `.glb` file assumes that the `.gltf` file does not have any associated resources (i.e. no references to buffers or textures). This is not generally true, and when trying to process arbitrary `.gltf` files, people seem to stumble over the _"Error: glTF model references separate files but no resourceDirectory is supplied"_.

Maybe updating the example will help.

(Yes, I also liked the simplicity that was suggested with the example in its original form, but ... there's a trade-off...)

Fixes https://github.com/CesiumGS/gltf-pipeline/issues/623

