### PR TITLE
Add base color names option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,27 +117,29 @@ processGltf(gltf, options).then(function (results) {
 
 ### Command-Line Flags
 
-| Flag                           | Description                                                                                                                    | Required               |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `--help`, `-h`                 | Display help                                                                                                                   | No                     |
-| `--input`, `-i`                | Path to the glTF or glb file.                                                                                                  | :white_check_mark: Yes |
-| `--output`, `-o`               | Output path of the glTF or glb file. Separate resources will be saved to the same directory.                                   | No                     |
-| `--binary`, `-b`               | Convert the input glTF to glb.                                                                                                 | No, default `false`    |
-| `--json`, `-j`                 | Convert the input glb to glTF.                                                                                                 | No, default `false`    |
-| `--separate`, `-s`             | Write separate buffers, shaders, and textures instead of embedding them in the glTF.                                           | No, default `false`    |
-| `--separateTextures`, `-t`     | Write out separate textures only.                                                                                              | No, default `false`    |
-| `--stats`                      | Print statistics to console for output glTF file.                                                                              | No, default `false`    |
-| `--keepUnusedElements`         | Keep unused materials, nodes and meshes.                                                                                       | No, default `false`    |
-| `--keepLegacyExtensions`       | When false, materials with `KHR_techniques_webgl`, `KHR_blend`, or `KHR_materials_common` will be converted to PBR.            | No, default `false`    |
-| `--draco.compressMeshes`, `-d` | Compress the meshes using Draco. Adds the `KHR_draco_mesh_compression` extension.                                              | No, default `false`    |
-| `--draco.compressionLevel`     | Draco compression level [0-10], most is 10, least is 0. A value of 0 will apply sequential encoding and preserve face order.   | No, default `7`        |
-| `--draco.quantizePositionBits` | Quantization bits for position attribute when using Draco compression.                                                         | No, default `11`       |
-| `--draco.quantizeNormalBits`   | Quantization bits for normal attribute when using Draco compression.                                                           | No, default `8`        |
-| `--draco.quantizeTexcoordBits` | Quantization bits for texture coordinate attribute when using Draco compression.                                               | No, default `10`       |
-| `--draco.quantizeColorBits`    | Quantization bits for color attribute when using Draco compression.                                                            | No, default `8`        |
-| `--draco.quantizeGenericBits`  | Quantization bits for skinning attribute (joint indices and joint weights) and custom attributes when using Draco compression. | No, default `8`        |
-| `--draco.unifiedQuantization`  | Quantize positions of all primitives using the same quantization grid. If not set, quantization is applied separately.         | No, default `false`    |
-| `--draco.uncompressedFallback` | Adds uncompressed fallback versions of the compressed meshes.                                                                  | No, default `false`    |
+| Flag                           | Description                                                                                                                                                  | Required                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `--help`, `-h`                 | Display help                                                                                                                                                 | No                                        |
+| `--input`, `-i`                | Path to the glTF or glb file.                                                                                                                                | :white_check_mark: Yes                    |
+| `--output`, `-o`               | Output path of the glTF or glb file. Separate resources will be saved to the same directory.                                                                 | No                                        |
+| `--binary`, `-b`               | Convert the input glTF to glb.                                                                                                                               | No, default `false`                       |
+| `--json`, `-j`                 | Convert the input glb to glTF.                                                                                                                               | No, default `false`                       |
+| `--separate`, `-s`             | Write separate buffers, shaders, and textures instead of embedding them in the glTF.                                                                         | No, default `false`                       |
+| `--separateTextures`, `-t`     | Write out separate textures only.                                                                                                                            | No, default `false`                       |
+| `--stats`                      | Print statistics to console for output glTF file.                                                                                                            | No, default `false`                       |
+| `--keepUnusedElements`         | Keep unused materials, nodes and meshes.                                                                                                                     | No, default `false`                       |
+| `--keepLegacyExtensions`       | When false, materials with `KHR_techniques_webgl`, `KHR_blend`, or `KHR_materials_common` will be converted to PBR.                                          | No, default `false`                       |
+| `--draco.compressMeshes`, `-d` | Compress the meshes using Draco. Adds the `KHR_draco_mesh_compression` extension.                                                                            | No, default `false`                       |
+| `--draco.compressionLevel`     | Draco compression level [0-10], most is 10, least is 0. A value of 0 will apply sequential encoding and preserve face order.                                 | No, default `7`                           |
+| `--draco.quantizePositionBits` | Quantization bits for position attribute when using Draco compression.                                                                                       | No, default `11`                          |
+| `--draco.quantizeNormalBits`   | Quantization bits for normal attribute when using Draco compression.                                                                                         | No, default `8`                           |
+| `--draco.quantizeTexcoordBits` | Quantization bits for texture coordinate attribute when using Draco compression.                                                                             | No, default `10`                          |
+| `--draco.quantizeColorBits`    | Quantization bits for color attribute when using Draco compression.                                                                                          | No, default `8`                           |
+| `--draco.quantizeGenericBits`  | Quantization bits for skinning attribute (joint indices and joint weights) and custom attributes when using Draco compression.                               | No, default `8`                           |
+| `--draco.unifiedQuantization`  | Quantize positions of all primitives using the same quantization grid. If not set, quantization is applied separately.                                       | No, default `false`                       |
+| `--draco.uncompressedFallback` | Adds uncompressed fallback versions of the compressed meshes.                                                                                                | No, default `false`                       |
+| `--baseColorTextureNames`      | Names of uniforms that should be considered to refer to base color textures <br /> when updating from the `KHR_techniques_webgl` extension to PBR materials. | No. (The defaults are not specified here) |
+| `--baseColorFactorNames`       | Names of uniforms that should be considered to refer to base color factors <br /> when updating from the `KHR_techniques_webgl` extension to PBR materials.  | No. (The defaults are not specified here) |
 
 ## Build Instructions
 

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -136,6 +136,16 @@ const argv = yargs
       type: "boolean",
       default: dracoDefaults.unifiedQuantization,
     },
+    baseColorTextureNames: {
+      describe:
+        "Names of uniforms that should be considered to refer to base color textures when updating from the KHR_techniques_webgl extension to PBR materials.",
+      type: "array",
+    },
+    baseColorFactorNames: {
+      describe:
+        "Names of uniforms that should be considered to refer to base color factors when updating from the KHR_techniques_webgl extension to PBR materials.",
+      type: "array",
+    },
   })
   .parse(args);
 
@@ -192,6 +202,8 @@ const options = {
   keepLegacyExtensions: argv.keepLegacyExtensions,
   name: outputName,
   dracoOptions: dracoOptions,
+  baseColorTextureNames: argv.baseColorTextureNames,
+  baseColorFactorNames: argv.baseColorFactorNames,
 };
 
 const inputIsBinary = inputExtension === ".glb";

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -78,7 +78,7 @@ function updateVersion(gltf, options) {
   }
 
   if (!options.keepLegacyExtensions) {
-    convertTechniquesToPbr(gltf);
+    convertTechniquesToPbr(gltf, options);
     convertMaterialsCommonToPbr(gltf);
   }
 
@@ -1008,8 +1008,13 @@ function glTF10to20(gltf) {
 // It's not possible to upgrade glTF 1.0 shaders to 2.0 PBR materials in a generic way,
 // but we can look for certain uniform names that are commonly found in glTF 1.0 assets
 // and create PBR materials out of those.
-const baseColorTextureNames = ["u_tex", "u_diffuse", "u_emission"];
-const baseColorFactorNames = ["u_diffuse"];
+const defaultBaseColorTextureNames = [
+  "u_tex",
+  "u_diffuse",
+  "u_emission",
+  "u_diffuse_tex",
+];
+const defaultBaseColorFactorNames = ["u_diffuse", "u_diffuse_mat"];
 
 function initializePbrMaterial(material) {
   material.pbrMetallicRoughness = defined(material.pbrMetallicRoughness)
@@ -1049,7 +1054,17 @@ function srgbToLinear(srgb) {
   return linear;
 }
 
-function convertTechniquesToPbr(gltf) {
+function convertTechniquesToPbr(gltf, options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  const baseColorTextureNames = defaultValue(
+    options.baseColorTextureNames,
+    defaultBaseColorTextureNames
+  );
+  const baseColorFactorNames = defaultValue(
+    options.baseColorFactorNames,
+    defaultBaseColorFactorNames
+  );
+
   // Future work: convert other values like emissive, specular, etc. Only handling diffuse right now.
   ForEach.material(gltf, function (material) {
     ForEach.materialValue(material, function (value, name) {

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -926,4 +926,43 @@ describe("updateVersion", () => {
     expect(gltf.extensionsUsed).toBeUndefined();
     expect(material.extensions).toBeUndefined();
   });
+
+  it("creates a PBR material from KHR_techniques_webgl with a custom diffuse texture name", async () => {
+    const gltf = fsExtra.readJsonSync(gltf2TechniquesTextured);
+    await readResources(gltf);
+
+    const options = {
+      baseColorTextureNames: ["u_diffuse"],
+    };
+    updateVersion(gltf, options);
+
+    expect(gltf.materials.length).toBe(1);
+
+    const material = gltf.materials[0];
+    expect(material.pbrMetallicRoughness.roughnessFactor).toBe(1.0);
+    expect(material.pbrMetallicRoughness.metallicFactor).toBe(0.0);
+    expect(material.pbrMetallicRoughness.baseColorTexture.index).toBe(0);
+
+    expect(gltf.extensionsRequired).toBeUndefined();
+    expect(gltf.extensionsUsed).toBeUndefined();
+  });
+
+  it("does not create a PBR material from KHR_techniques_webgl when the diffuse texture name is unknown", async () => {
+    const gltf = fsExtra.readJsonSync(gltf2TechniquesTextured);
+    await readResources(gltf);
+
+    const options = {
+      baseColorTextureNames: ["NOT_u_diffuse"],
+    };
+    updateVersion(gltf, options);
+
+    expect(gltf.materials.length).toBe(1);
+
+    const material = gltf.materials[0];
+    expect(material.pbrMetallicRoughness).toBeUndefined();
+    expect(material.extensions).toBeUndefined();
+
+    expect(gltf.extensionsRequired).toBeUndefined();
+    expect(gltf.extensionsUsed).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Adds an option to specify the names of base color texture and factor uniforms when updating glTF with KHR_techniques_webgl extension to PBR.

By default, `gltf-pipeline` will try to convert materials that use the `KHR_techniques_webgl` extension into PBR materials. This is not possible generically, but it is possible to make some "educated guesses". Specifically, it is possible to _guess_ which texture is supposed to be the PBR `baseColorTexture` by looking at the name of the uniform in the techniques definition: When the uniform is called `u_diffuse` (and refers to a texture), then it is very likely that this texture is supposed to become the `baseColorTexture`.  

The [set of names that suggest that a texture may become a base color texture](https://github.com/CesiumGS/gltf-pipeline/blob/901c94f360d60382dfbc8612c12130bc4992f10c/lib/updateVersion.js#L1011) is ... somewhat arbitrary. One can never know which names one might encounter in the wild.

This PR adds an option to specify the base color texture names at the command line and pass them to the update function in the `options` object. For example, when a GLB contains techniques where the uniform names are `u_my_diffuse_tex` and `u_another_diffuse_tex`, then the line
```
node ./bin/gltf-pipeline.js -i input.glb -o output.glb --baseColorTextureNames u_my_diffuse_tex u_another_diffuse_tex
```
will cause these names to be treated as indicators for the textures to become `baseColorTexture`.

(All this applies to the base color *factors* as well, with `baseColorFactors` as the command line option)

---

Things to consider:

The README marks these arguments as 'optional', but _explicitly_ says that the set of "default names" for this is not specified. I'd hesitate to explicitly list things like `"u_tex", "u_diffuse", "u_emission", "u_diffuse_tex"` there...

The current approach is somewhat "fail silent" in nature. When someone has a GLB where such a name is `u_diff_tex`, then this texture will just be removed, and it may not be obvious for the user why this happened. Loading the model in a viewer might give the impression that the _viewer_ can not display the texture for some reason (with that 'reason' being the too obvious one: It's not there...).

I considered to bring a few more high-level guesses into that conversion, and/or add some sort of warning or hint when something looks odd. For example:

- If the technique values contains only a *single* texture reference
- And if this texture reference does not have one of the known names 
- And (maybe:) If this texture becomes unused when the technique is omitted
- Then print a warning: 
  > Warning: Omitting texture that is used via uniform `u_diff_t`, because it is not one of the known diffuse texture names. See (link to readme) for details.

I think that could help to avoid some confusion for users, some support requests, and save some debugging time...



