### PR TITLE
Dependencies updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const fsExtra = require("fs-extra");
 const gulp = require("gulp");
 const Jasmine = require("jasmine");
 const JasmineSpecReporter = require("jasmine-spec-reporter").SpecReporter;
-const open = require("open");
 const path = require("path");
 const Promise = require("bluebird");
 const yargs = require("yargs");
@@ -86,7 +85,6 @@ function coverage() {
       stdio: [process.stdin, process.stdout, process.stderr],
     }
   );
-  open("coverage/lcov-report/index.html");
 
   return Promise.resolve();
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
     "open": "^8.3.0",
-    "prettier": "2.8.4",
+    "prettier": "2.8.8",
     "pretty-quick": "^3.1.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
-    "open": "^8.3.0",
     "prettier": "2.8.8",
     "pretty-quick": "^3.1.1"
   },


### PR DESCRIPTION
Only dev dependency updates:
1. Removes `open` library from the `package.json` and `gulpfile` since it is now an ESM only package and isn't very useful
2. Updates `prettier` to latest version