### PR TITLE
Use primitive type instead of constructor type

### DIFF
--- a/lib/addBuffer.js
+++ b/lib/addBuffer.js
@@ -6,9 +6,9 @@ module.exports = addBuffer;
 /**
  * Adds buffer to gltf.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {object} gltf A javascript object containing a glTF asset.
  * @param {Buffer} buffer A Buffer object which will be added to gltf.buffers.
- * @returns {Number} The bufferView id of the newly added bufferView.
+ * @returns {number} The bufferView id of the newly added bufferView.
  *
  * @private
  */

--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -13,8 +13,8 @@ module.exports = addDefaults;
 /**
  * Adds default glTF values if they don't exist.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} The modified glTF.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} The modified glTF.
  *
  * @private
  */

--- a/lib/addExtensionsRequired.js
+++ b/lib/addExtensionsRequired.js
@@ -11,8 +11,8 @@ module.exports = addExtensionsRequired;
  * Adds an extension to gltf.extensionsRequired if it does not already exist.
  * Initializes extensionsRequired if it is not defined.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The extension to add.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The extension to add.
  *
  * @private
  */

--- a/lib/addExtensionsUsed.js
+++ b/lib/addExtensionsUsed.js
@@ -10,8 +10,8 @@ module.exports = addExtensionsUsed;
  * Adds an extension to gltf.extensionsUsed if it does not already exist.
  * Initializes extensionsUsed if it is not defined.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The extension to add.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The extension to add.
  *
  * @private
  */

--- a/lib/addPipelineExtras.js
+++ b/lib/addPipelineExtras.js
@@ -10,8 +10,8 @@ module.exports = addPipelineExtras;
  * Adds extras._pipeline to each object that can have extras in the glTF asset.
  * This stage runs before updateVersion and handles both glTF 1.0 and glTF 2.0 assets.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} The glTF asset with the added pipeline extras.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} The glTF asset with the added pipeline extras.
  *
  * @private
  */

--- a/lib/addToArray.js
+++ b/lib/addToArray.js
@@ -9,8 +9,8 @@ module.exports = addToArray;
  * Adds an element to an array and returns the element's index.
  *
  * @param {Array} array The array to add to.
- * @param {Object} element The element to add.
- * @param {Boolean} [checkDuplicates=false] When <code>true</code>, if a duplicate element is found its index is returned and <code>element</code> is not added to the array.
+ * @param {object} element The element to add.
+ * @param {boolean} [checkDuplicates=false] When <code>true</code>, if a duplicate element is found its index is returned and <code>element</code> is not added to the array.
  *
  * @private
  */

--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -31,18 +31,18 @@ module.exports = compressDracoMeshes;
 /**
  * Compresses meshes using Draco compression in the glTF model.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} options The same options object as {@link processGltf}
- * @param {Object} options.dracoOptions Options defining Draco compression settings.
- * @param {Number} [options.dracoOptions.compressionLevel=7] A value between 0 and 10 specifying the quality of the Draco compression. Higher values produce better quality compression but may take longer to decompress. A value of 0 will apply sequential encoding and preserve face order.
- * @param {Number} [options.dracoOptions.quantizePositionBits=11] A value between 0 and 30 specifying the number of bits used for positions. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
- * @param {Number} [options.dracoOptions.quantizeNormalBits=8] A value between 0 and 30 specifying the number of bits used for normals. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
- * @param {Number} [options.dracoOptions.quantizeTexcoordBits=10] A value between 0 and 30 specifying the number of bits used for texture coordinates. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
- * @param {Number} [options.dracoOptions.quantizeColorBits=8] A value between 0 and 30 specifying the number of bits used for color attributes. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
- * @param {Number} [options.dracoOptions.quantizeGenericBits=8] A value between 0 and 30 specifying the number of bits used for skinning attributes (joint indices and joint weights) and custom attributes. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
- * @param {Boolean} [options.dracoOptions.uncompressedFallback=false] If set, add uncompressed fallback versions of the compressed meshes.
- * @param {Boolean} [options.dracoOptions.unifiedQuantization=false] Quantize positions, defined by the unified bounding box of all primitives. If not set, quantization is applied separately.
- * @param {Object} [options.dracoOptions.quantizationVolume] An AxisAlignedBoundingBox defining the explicit quantization volume.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} options The same options object as {@link processGltf}
+ * @param {object} options.dracoOptions Options defining Draco compression settings.
+ * @param {number} [options.dracoOptions.compressionLevel=7] A value between 0 and 10 specifying the quality of the Draco compression. Higher values produce better quality compression but may take longer to decompress. A value of 0 will apply sequential encoding and preserve face order.
+ * @param {number} [options.dracoOptions.quantizePositionBits=11] A value between 0 and 30 specifying the number of bits used for positions. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
+ * @param {number} [options.dracoOptions.quantizeNormalBits=8] A value between 0 and 30 specifying the number of bits used for normals. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
+ * @param {number} [options.dracoOptions.quantizeTexcoordBits=10] A value between 0 and 30 specifying the number of bits used for texture coordinates. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
+ * @param {number} [options.dracoOptions.quantizeColorBits=8] A value between 0 and 30 specifying the number of bits used for color attributes. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
+ * @param {number} [options.dracoOptions.quantizeGenericBits=8] A value between 0 and 30 specifying the number of bits used for skinning attributes (joint indices and joint weights) and custom attributes. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
+ * @param {boolean} [options.dracoOptions.uncompressedFallback=false] If set, add uncompressed fallback versions of the compressed meshes.
+ * @param {boolean} [options.dracoOptions.unifiedQuantization=false] Quantize positions, defined by the unified bounding box of all primitives. If not set, quantization is applied separately.
+ * @param {object} [options.dracoOptions.quantizationVolume] An AxisAlignedBoundingBox defining the explicit quantization volume.
  * @returns {Promise} A promise that resolves to the glTF asset with compressed meshes.
  *
  * @private

--- a/lib/dataUriToBuffer.js
+++ b/lib/dataUriToBuffer.js
@@ -4,7 +4,7 @@ module.exports = dataUriToBuffer;
 /**
  * Read a data uri string into a buffer.
  *
- * @param {String} dataUri The data uri.
+ * @param {string} dataUri The data uri.
  * @returns {Buffer}
  *
  * @private

--- a/lib/findAccessorMinMax.js
+++ b/lib/findAccessorMinMax.js
@@ -13,8 +13,8 @@ module.exports = findAccessorMinMax;
 /**
  * Finds the min and max values of the accessor.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} accessor The accessor object from the glTF asset to read.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} accessor The accessor object from the glTF asset to read.
  * @returns {{min: Array, max: Array}} min holding the array of minimum values and max holding the array of maximum values.
  *
  * @private

--- a/lib/forEachTextureInMaterial.js
+++ b/lib/forEachTextureInMaterial.js
@@ -11,7 +11,7 @@ module.exports = forEachTextureInMaterial;
 /**
  * Calls the provider handler function on each texture used by the material.
  * Mimics the behavior of functions in gltf-pipeline ForEach.
- * @param {Object} material The glTF material.
+ * @param {object} material The glTF material.
  * @param {forEachTextureInMaterial~handler} handler Function that is called for each texture in the material.
  *
  * @private
@@ -136,8 +136,8 @@ function forEachTextureInMaterial(material, handler) {
 /**
  * Function that is called for each texture in the material. If this function returns a value the for each stops and returns that value.
  * @callback forEachTextureInMaterial~handler
- * @param {Number} The texture index.
- * @param {Object} The texture info object.
+ * @param {number} The texture index.
+ * @param {object} The texture info object.
  *
  * @private
  */

--- a/lib/getAccessorByteStride.js
+++ b/lib/getAccessorByteStride.js
@@ -11,9 +11,9 @@ module.exports = getAccessorByteStride;
  * Returns the byte stride of the provided accessor.
  * If the byteStride is 0, it is calculated based on type and componentType
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} accessor The accessor.
- * @returns {Number} The byte stride of the accessor.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} accessor The accessor.
+ * @returns {number} The byte stride of the accessor.
  *
  * @private
  */

--- a/lib/getComponentReader.js
+++ b/lib/getComponentReader.js
@@ -8,7 +8,7 @@ module.exports = getComponentReader;
 /**
  * Returns a function to read and convert data from a DataView into an array.
  *
- * @param {Number} componentType Type to convert the data to.
+ * @param {number} componentType Type to convert the data to.
  * @returns {ComponentReader} Function that reads and converts data.
  *
  * @private
@@ -141,10 +141,10 @@ function getComponentReader(componentType) {
  * @callback ComponentReader
  *
  * @param {DataView} dataView The data view to read from.
- * @param {Number} byteOffset The byte offset applied when reading from the data view.
- * @param {Number} numberOfComponents The number of components to read.
- * @param {Number} componentTypeByteLength The byte length of each component.
- * @param {Number} result An array storing the components that are read.
+ * @param {number} byteOffset The byte offset applied when reading from the data view.
+ * @param {number} numberOfComponents The number of components to read.
+ * @param {number} componentTypeByteLength The byte length of each component.
+ * @param {number} result An array storing the components that are read.
  *
  * @private
  */

--- a/lib/getImageExtension.js
+++ b/lib/getImageExtension.js
@@ -9,7 +9,7 @@ module.exports = getImageExtension;
  * Get the image extension from a Buffer containing image data.
  *
  * @param {Buffer} data The image data.
- * @returns {String} The image extension.
+ * @returns {string} The image extension.
  *
  * @private
  */

--- a/lib/getJsonBufferPadded.js
+++ b/lib/getJsonBufferPadded.js
@@ -12,8 +12,8 @@ module.exports = getJsonBufferPadded;
  * for the section that follows. glTF only requires 4-byte alignment but some extensions like
  * EXT_structural_metadata require 8-byte alignment for some buffer views.
  *
- * @param {Object} json The JSON object.
- * @param {Number} [byteOffset=0] The byte offset on which the buffer starts.
+ * @param {object} json The JSON object.
+ * @param {number} [byteOffset=0] The byte offset on which the buffer starts.
  * @returns {Buffer} The padded JSON buffer.
  *
  * @private

--- a/lib/getStatistics.js
+++ b/lib/getStatistics.js
@@ -11,8 +11,8 @@ module.exports = getStatistics;
 /**
  * Returns an object containing the statistics for the glTF asset.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Number} [nodeId] If defined, statistics will only process number of draw calls and rendered primitives for the specified node.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {number} [nodeId] If defined, statistics will only process number of draw calls and rendered primitives for the specified node.
  * @returns {Statistics} Object containing the statistics of the glTF asset.
  *
  * @see Statistics
@@ -148,15 +148,15 @@ function getDrawCallStatistics(gltf) {
 /**
  * Contains statistics for a glTF asset.
  *
- * @property {Number} buffersByteLength The total byte length of all buffers.
- * @property {Number} numberOfImages The number of images in the asset.
- * @property {Number} numberOfExternalRequests The number of external requests required to fetch the asset data.
- * @property {Number} numberOfDrawCalls The number of draw calls required to render the asset.
- * @property {Number} numberOfRenderedPrimitives The total number of rendered primitives in the asset (e.g. triangles).
- * @property {Number} numberOfNodes The total number of nodes in the asset.
- * @property {Number} numberOfMeshes The total number of meshes in the asset.
- * @property {Number} numberOfMaterials The total number of materials in the asset.
- * @property {Number} numberOfAnimations The total number of animations in the asset.
+ * @property {number} buffersByteLength The total byte length of all buffers.
+ * @property {number} numberOfImages The number of images in the asset.
+ * @property {number} numberOfExternalRequests The number of external requests required to fetch the asset data.
+ * @property {number} numberOfDrawCalls The number of draw calls required to render the asset.
+ * @property {number} numberOfRenderedPrimitives The total number of rendered primitives in the asset (e.g. triangles).
+ * @property {number} numberOfNodes The total number of nodes in the asset.
+ * @property {number} numberOfMeshes The total number of meshes in the asset.
+ * @property {number} numberOfMaterials The total number of materials in the asset.
+ * @property {number} numberOfAnimations The total number of animations in the asset.
  *
  * @constructor
  *
@@ -177,7 +177,7 @@ function Statistics() {
 /**
  * Creates a string listing the statistics along with their descriptions.
  *
- * @returns {String} A string describing the statistics for the glTF asset.
+ * @returns {string} A string describing the statistics for the glTF asset.
  */
 Statistics.prototype.toString = function () {
   return (

--- a/lib/glbToGltf.js
+++ b/lib/glbToGltf.js
@@ -8,7 +8,7 @@ module.exports = glbToGltf;
  * Convert a glb to glTF.
  *
  * @param {Buffer} glb A buffer containing the glb contents.
- * @param {Object} [options] The same options object as {@link processGltf}
+ * @param {object} [options] The same options object as {@link processGltf}
  * @returns {Promise} A promise that resolves to an object containing the glTF and a dictionary containing separate resources.
  */
 function glbToGltf(glb, options) {

--- a/lib/gltfToGlb.js
+++ b/lib/gltfToGlb.js
@@ -11,8 +11,8 @@ module.exports = gltfToGlb;
 /**
  * Convert a glTF to glb.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} [options] The same options object as {@link processGltf}
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} [options] The same options object as {@link processGltf}
  * @returns {Promise} A promise that resolves to an object containing the glb and a dictionary containing separate resources.
  */
 function gltfToGlb(gltf, options) {

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -13,10 +13,10 @@ module.exports = mergeBuffers;
 /**
  * Merge all buffers. Buffers with the same extras._pipeline.mergedBufferName will be merged together.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} [defaultName] The default name of the buffer data files.
- * @param {Boolean} [force=false] Whether to force merging all buffers.
- * @returns {Object} The glTF asset with its buffers merged.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} [defaultName] The default name of the buffer data files.
+ * @param {boolean} [force=false] Whether to force merging all buffers.
+ * @returns {object} The glTF asset with its buffers merged.
  *
  * @private
  */

--- a/lib/moveTechniqueRenderStates.js
+++ b/lib/moveTechniqueRenderStates.js
@@ -59,8 +59,8 @@ function getSupportedBlendFactors(value, defaultValue) {
 /**
  * Move glTF 1.0 technique render states to glTF 2.0 materials properties and KHR_blend extension.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} The updated glTF asset.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} The updated glTF asset.
  *
  * @private
  */

--- a/lib/moveTechniquesToExtension.js
+++ b/lib/moveTechniquesToExtension.js
@@ -13,8 +13,8 @@ module.exports = moveTechniquesToExtension;
 /**
  * Move glTF 1.0 material techniques to glTF 2.0 KHR_techniques_webgl extension.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} The updated glTF asset.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} The updated glTF asset.
  *
  * @private
  */

--- a/lib/numberOfComponentsForType.js
+++ b/lib/numberOfComponentsForType.js
@@ -5,8 +5,8 @@ module.exports = numberOfComponentsForType;
 /**
  * Utility function for retrieving the number of components in a given type.
  *
- * @param {String} type glTF type
- * @returns {Number} The number of components in that type.
+ * @param {string} type glTF type
+ * @returns {number} The number of components in that type.
  *
  * @private
  */

--- a/lib/parseGlb.js
+++ b/lib/parseGlb.js
@@ -19,7 +19,7 @@ module.exports = parseGlb;
  * The returned glTF has pipeline extras included. The embedded binary data is stored in gltf.buffers[0].extras._pipeline.source.
  *
  * @param {Buffer} glb The glb data to parse.
- * @returns {Object} A javascript object containing a glTF asset with pipeline extras included.
+ * @returns {object} A javascript object containing a glTF asset with pipeline extras included.
  *
  * @private
  */

--- a/lib/processGlb.js
+++ b/lib/processGlb.js
@@ -8,7 +8,7 @@ module.exports = processGlb;
  * Run a glb through the gltf-pipeline.
  *
  * @param {Buffer} glb A buffer containing the glb contents.
- * @param {Object} [options] The same options object as {@link processGltf}
+ * @param {object} [options] The same options object as {@link processGltf}
  * @returns {Promise} A promise that resolves to an object containing the glb and a dictionary containing separate resources.
  */
 function processGlb(glb, options) {

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -21,18 +21,18 @@ module.exports = processGltf;
 /**
  * Run a glTF through the gltf-pipeline.
  *
- * @param {Object} gltf A javascript object containing a glTF asset. The glTF is modified in place.
- * @param {Object} [options] An object with the following properties:
- * @param {String} [options.resourceDirectory] The path for reading separate resources.
- * @param {String} [options.name] The name of the glTF asset, for writing separate resources.
- * @param {Boolean} [options.separate = false] Write separate buffers, shaders, and textures instead of embedding them in the glTF.
- * @param {Boolean} [options.separateTextures = false] Write out separate textures only.
- * @param {Boolean} [options.stats = false] Print statistics to console for input and output glTF files.
- * @param {Object} [options.dracoOptions] Options to pass to the compressDracoMeshes stage. If undefined, stage is not run.
+ * @param {object} gltf A javascript object containing a glTF asset. The glTF is modified in place.
+ * @param {object} [options] An object with the following properties:
+ * @param {string} [options.resourceDirectory] The path for reading separate resources.
+ * @param {string} [options.name] The name of the glTF asset, for writing separate resources.
+ * @param {boolean} [options.separate = false] Write separate buffers, shaders, and textures instead of embedding them in the glTF.
+ * @param {boolean} [options.separateTextures = false] Write out separate textures only.
+ * @param {boolean} [options.stats = false] Print statistics to console for input and output glTF files.
+ * @param {object} [options.dracoOptions] Options to pass to the compressDracoMeshes stage. If undefined, stage is not run.
  * @param {Stage[]} [options.customStages] Custom stages to run on the glTF asset.
  * @param {Logger} [options.logger] A callback function for handling logged messages. Defaults to console.log.
- * @param {String[]} [options.baseColorTextureNames] Names of uniforms that indicate base color textures.
- * @param {String[]} [options.baseColorFactorNames] Names of uniforms that indicate base color factors.
+ * @param {string[]} [options.baseColorTextureNames] Names of uniforms that indicate base color textures.
+ * @param {string[]} [options.baseColorFactorNames] Names of uniforms that indicate base color factors.
  *
  * @returns {Promise} A promise that resolves to an object containing the glTF and a dictionary containing separate resources.
  */
@@ -148,13 +148,13 @@ processGltf.defaults = {
  * A callback function that logs messages.
  * @callback Logger
  *
- * @param {String} message The message to log.
+ * @param {string} message The message to log.
  */
 
 /**
  * A stage that processes a glTF asset.
  * @callback Stage
  *
- * @param {Object} gltf The glTF asset.
+ * @param {object} gltf The glTF asset.
  * @returns {Promise|Object} The glTF asset or a promise that resolves to the glTF asset.
  */

--- a/lib/readAccessorPacked.js
+++ b/lib/readAccessorPacked.js
@@ -12,8 +12,8 @@ module.exports = readAccessorPacked;
 /**
  * Returns the accessor data in a contiguous array.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} accessor The accessor.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} accessor The accessor.
  * @returns {Array} The accessor values in a contiguous array.
  *
  * @private

--- a/lib/readResources.js
+++ b/lib/readResources.js
@@ -22,9 +22,9 @@ module.exports = readResources;
  * The buffer data is placed into extras._pipeline.source for the corresponding object.
  * This stage runs before updateVersion and handles both glTF 1.0 and glTF 2.0 assets.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} [options] Object with the following properties:
- * @param {String} [options.resourceDirectory] The path to look in when reading separate files.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} [options] Object with the following properties:
+ * @param {string} [options.resourceDirectory] The path to look in when reading separate files.
  * @returns {Promise} A promise that resolves to the glTF asset when all resources are read.
  *
  * @private

--- a/lib/removeDefaults.js
+++ b/lib/removeDefaults.js
@@ -10,8 +10,8 @@ module.exports = removeDefaults;
 /**
  * Remove default values from the glTF. Not exhaustive.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} glTF with default values removed.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} glTF with default values removed.
  *
  * @private
  */

--- a/lib/removeExtension.js
+++ b/lib/removeExtension.js
@@ -10,8 +10,8 @@ module.exports = removeExtension;
 /**
  * Removes an extension from gltf.extensions, gltf.extensionsUsed, gltf.extensionsRequired, and any other objects in the glTF if it is present.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The extension to remove.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The extension to remove.
  *
  * @returns {*} The extension data removed from gltf.extensions.
  */

--- a/lib/removeExtensionsRequired.js
+++ b/lib/removeExtensionsRequired.js
@@ -8,8 +8,8 @@ module.exports = removeExtensionsRequired;
 /**
  * Removes an extension from gltf.extensionsRequired if it is present.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The extension to remove.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The extension to remove.
  *
  * @private
  */

--- a/lib/removeExtensionsUsed.js
+++ b/lib/removeExtensionsUsed.js
@@ -9,8 +9,8 @@ module.exports = removeExtensionsUsed;
 /**
  * Removes an extension from gltf.extensionsUsed and gltf.extensionsRequired if it is present.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The extension to remove.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The extension to remove.
  *
  * @private
  */

--- a/lib/removePipelineExtras.js
+++ b/lib/removePipelineExtras.js
@@ -9,8 +9,8 @@ module.exports = removePipelineExtras;
 /**
  * Iterate through the objects within the glTF and delete their pipeline extras object.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} glTF with no pipeline extras.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} glTF with no pipeline extras.
  *
  * @private
  */

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -24,8 +24,8 @@ const allElementTypes = [
 /**
  * Removes unused elements from gltf.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String[]} [elementTypes=['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer']] Element types to be removed. Needs to be a subset of ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'], other items will be ignored.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string[]} [elementTypes=['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer']] Element types to be removed. Needs to be a subset of ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'], other items will be ignored.
  *
  * @private
  */

--- a/lib/replaceWithDecompressedPrimitive.js
+++ b/lib/replaceWithDecompressedPrimitive.js
@@ -12,16 +12,16 @@ module.exports = replaceWithDecompressedPrimitive;
 /**
  * Replace the accessor properties of the original primitive with the values from the decompressed primitive.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} primitive A javascript object containing a glTF primitive.
- * @param {Object} dracoEncodedBuffer A javascript object containing a Draco encoded mesh.
- * @param {Number} dracoEncodedBuffer.numberOfPoints Number of points after the mesh is decompressed.
- * @param {Number} dracoEncodedBuffer.numberOfFaces Number of faces after the mesh is decompressed.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} primitive A javascript object containing a glTF primitive.
+ * @param {object} dracoEncodedBuffer A javascript object containing a Draco encoded mesh.
+ * @param {number} dracoEncodedBuffer.numberOfPoints Number of points after the mesh is decompressed.
+ * @param {number} dracoEncodedBuffer.numberOfFaces Number of faces after the mesh is decompressed.
  * @param {Buffer} dracoEncodedBuffer.buffer A Buffer object containing a Draco compressed mesh.
- * @param {Boolean} uncompressedFallback If set, replaces the original with the decompressed data.
- * @param {Object} quantizationBitsValues A javascript object containing quantization bits for the different attribute types.
- * @param {Object} decoderModule The draco decoder module.
- * @returns {Object} The glTF asset with the decompressed primitive.
+ * @param {boolean} uncompressedFallback If set, replaces the original with the decompressed data.
+ * @param {object} quantizationBitsValues A javascript object containing quantization bits for the different attribute types.
+ * @param {object} decoderModule The draco decoder module.
+ * @returns {object} The glTF asset with the decompressed primitive.
  *
  * @private
  */

--- a/lib/splitPrimitives.js
+++ b/lib/splitPrimitives.js
@@ -20,8 +20,8 @@ module.exports = splitPrimitives;
  * Splits primitives that reference different indices within the same mesh.
  * This stage is used internally by compressDracoMeshes.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} glTF with primitives split.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} glTF with primitives split.
  *
  * @private
  */

--- a/lib/updateAccessorComponentTypes.js
+++ b/lib/updateAccessorComponentTypes.js
@@ -12,8 +12,8 @@ module.exports = updateAccessorComponentTypes;
 /**
  * Update accessors referenced by JOINTS_0 and WEIGHTS_0 attributes to use correct component types.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object} The glTF asset with compressed meshes.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @returns {object} The glTF asset with compressed meshes.
  *
  * @private
  */

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -35,12 +35,12 @@ const updateFunctions = {
  * Applies changes made to the glTF spec between revisions so that the core library
  * only has to handle the latest version.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} [options] Options for updating the glTF.
- * @param {String} [options.targetVersion] The glTF will be upgraded until it hits the specified version.
- * @param {String[]} [options.baseColorTextureNames] Names of uniforms that indicate base color textures.
- * @param {String[]} [options.baseColorFactorNames] Names of uniforms that indicate base color factors.
- * @returns {Object} The updated glTF asset.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} [options] Options for updating the glTF.
+ * @param {string} [options.targetVersion] The glTF will be upgraded until it hits the specified version.
+ * @param {string[]} [options.baseColorTextureNames] Names of uniforms that indicate base color textures.
+ * @param {string[]} [options.baseColorFactorNames] Names of uniforms that indicate base color factors.
+ * @returns {object} The updated glTF asset.
  *
  * @private
  */

--- a/lib/usesExtension.js
+++ b/lib/usesExtension.js
@@ -8,9 +8,9 @@ module.exports = usesExtension;
 /**
  * Checks whether the glTF uses the given extension.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} extension The name of the extension.
- * @returns {Boolean} Whether the glTF uses the given extension.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {string} extension The name of the extension.
+ * @returns {boolean} Whether the glTF uses the given extension.
  *
  * @private
  */

--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -25,17 +25,17 @@ module.exports = writeResources;
 /**
  * Write glTF resources as data uris, buffer views, or files.
  *
- * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Object} [options] Object with the following properties:
- * @param {String} [options.name] The name of the glTF asset, for writing separate resources.
- * @param {Boolean} [options.separateBuffers=false] Whether to save buffers as separate files.
- * @param {Boolean} [options.separateShaders=false] Whether to save shaders as separate files.
- * @param {Boolean} [options.separateTextures=false] Whether to save images as separate files.
- * @param {Boolean} [options.forceMergeBuffers=false] Whether to force merging all buffers.
- * @param {Boolean} [options.dataUris=false] Write embedded resources as data uris instead of buffer views.
- * @param {Object} [options.bufferStorage] When defined, the glTF buffer's underlying Buffer object will be saved here instead of encoded as a data uri or saved as a separate resource.
- * @param {Object} [options.separateResources] When defined, buffers of separate resources will be saved here.
- * @returns {Object} The glTF asset.
+ * @param {object} gltf A javascript object containing a glTF asset.
+ * @param {object} [options] Object with the following properties:
+ * @param {string} [options.name] The name of the glTF asset, for writing separate resources.
+ * @param {boolean} [options.separateBuffers=false] Whether to save buffers as separate files.
+ * @param {boolean} [options.separateShaders=false] Whether to save shaders as separate files.
+ * @param {boolean} [options.separateTextures=false] Whether to save images as separate files.
+ * @param {boolean} [options.forceMergeBuffers=false] Whether to force merging all buffers.
+ * @param {boolean} [options.dataUris=false] Write embedded resources as data uris instead of buffer views.
+ * @param {object} [options.bufferStorage] When defined, the glTF buffer's underlying Buffer object will be saved here instead of encoded as a data uri or saved as a separate resource.
+ * @param {object} [options.separateResources] When defined, buffers of separate resources will be saved here.
+ * @returns {object} The glTF asset.
  *
  * @private
  */


### PR DESCRIPTION
Following https://github.com/CesiumGS/cesium/pull/11080, this PR updates docstrings to use lower case when the type is a [JavaScript Primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).