### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18 ]
+        node: [ 16, 20 ]
     name: Node ${{ matrix.node }}
     steps:
     - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
     "prettier": "3.0.3",
-    "lint-staged": "^14.0.1"
+    "lint-staged": "^15.0.2"
   },
   "lint-staged": {
     "*.(js|ts)": [


### PR DESCRIPTION
update github actions to use node 20 and update lint staged to 15 (only major change is that it requries node 18 now to run)

Only outdated dependency was lint staged: 14 -> 15.0.2 (major change was support dropped for node 16 and 18 is the minimum requirement: https://github.com/lint-staged/lint-staged/releases/tag/v15.0.0)

No code changes