### PR TITLE
Update prettier

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -221,8 +221,8 @@ const run = inputIsBinary
     ? processGlb
     : glbToGltf
   : outputIsBinary
-  ? gltfToGlb
-  : processGltf;
+    ? gltfToGlb
+    : processGltf;
 
 function saveSeparateResources(separateResources) {
   const resourcePromises = [];

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -593,9 +593,8 @@ getListOfElementsIdsInUse.buffer = function (gltf) {
       defined(bufferView.extensions) &&
       defined(bufferView.extensions.EXT_meshopt_compression)
     ) {
-      usedBufferIds[
-        bufferView.extensions.EXT_meshopt_compression.buffer
-      ] = true;
+      usedBufferIds[bufferView.extensions.EXT_meshopt_compression.buffer] =
+        true;
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jasmine-spec-reporter": "^7.0.0",
     "jsdoc": "^4.0.0",
     "nyc": "^15.1.0",
-    "prettier": "3.0.3",
+    "prettier": "3.1.1",
     "lint-staged": "^15.0.2"
   },
   "lint-staged": {


### PR DESCRIPTION
Updates prettier to latest version. 

The only library pinned here is `mime` because it requires ESM