### PR TITLE
Use fallback textures for base color when no diffuse is given

### DIFF
--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -1084,6 +1084,26 @@ function convertTechniquesToPbr(gltf, options) {
   removeExtension(gltf, "KHR_blend");
 }
 
+function assignAsBaseColor(material, baseColor) {
+  if (defined(baseColor)) {
+    if (isVec4(baseColor)) {
+      material.pbrMetallicRoughness.baseColorFactor = srgbToLinear(baseColor);
+    } else if (isTexture(baseColor)) {
+      material.pbrMetallicRoughness.baseColorTexture = baseColor;
+    }
+  }
+}
+
+function assignAsEmissive(material, emissive) {
+  if (defined(emissive)) {
+    if (isVec4(emissive)) {
+      material.emissiveFactor = emissive.slice(0, 3);
+    } else if (isTexture(emissive)) {
+      material.emissiveTexture = emissive;
+    }
+  }
+}
+
 function convertMaterialsCommonToPbr(gltf) {
   // Future work: convert KHR_materials_common lights to KHR_lights_punctual
   ForEach.material(gltf, function (material) {
@@ -1091,79 +1111,60 @@ function convertMaterialsCommonToPbr(gltf) {
       material.extensions,
       defaultValue.EMPTY_OBJECT,
     ).KHR_materials_common;
+    if (!defined(materialsCommon)) {
+      // Nothing to do
+      return;
+    }
 
-    if (defined(materialsCommon)) {
-      const technique = materialsCommon.technique;
-      if (technique === "CONSTANT") {
-        // Add the KHR_materials_unlit extension
-        addExtensionsUsed(gltf, "KHR_materials_unlit");
-        material.extensions = defined(material.extensions)
-          ? material.extensions
-          : {};
-        material.extensions["KHR_materials_unlit"] = {};
-      }
+    const values = defaultValue(materialsCommon.values, {});
+    const ambient = values.ambient;
+    const diffuse = values.diffuse;
+    const emission = values.emission;
+    const transparency = values.transparency;
 
-      const values = defined(materialsCommon.values)
-        ? materialsCommon.values
+    // These actually exist on the extension object, not the values object despite what's shown in the spec
+    const doubleSided = materialsCommon.doubleSided;
+    const transparent = materialsCommon.transparent;
+
+    // Ignore specular and shininess for now because the conversion to PBR
+    // isn't straightforward and depends on the technique
+    initializePbrMaterial(material);
+
+    const technique = materialsCommon.technique;
+    if (technique === "CONSTANT") {
+      // Add the KHR_materials_unlit extension
+      addExtensionsUsed(gltf, "KHR_materials_unlit");
+      material.extensions = defined(material.extensions)
+        ? material.extensions
         : {};
+      material.extensions["KHR_materials_unlit"] = {};
 
-      const ambient = values.ambient;
-      const diffuse = values.diffuse;
-      const emission = values.emission;
-      const transparency = values.transparency;
+      // The CONSTANT technique does not support 'diffuse', so
+      // assign either the 'emission' or the 'ambient' as the
+      // base color
+      assignAsBaseColor(material, emission);
+      assignAsBaseColor(material, ambient);
+    } else {
+      // Assign the 'diffuse' as the base color, and
+      // the 'ambient' or 'emissive' as the emissive
+      // part if they are present.
+      assignAsBaseColor(material, diffuse);
+      assignAsEmissive(material, ambient);
+      assignAsEmissive(material, emission);
+    }
 
-      // These actually exist on the extension object, not the values object despite what's shown in the spec
-      const doubleSided = materialsCommon.doubleSided;
-      const transparent = materialsCommon.transparent;
-
-      // Ignore specular and shininess for now because the conversion to PBR
-      // isn't straightforward and depends on the technique
-      initializePbrMaterial(material);
-
-      if (defined(ambient)) {
-        if (isVec4(ambient)) {
-          material.emissiveFactor = ambient.slice(0, 3);
-        } else if (isTexture(ambient)) {
-          material.emissiveTexture = ambient;
-        }
+    if (defined(doubleSided)) {
+      material.doubleSided = doubleSided;
+    }
+    if (defined(transparency)) {
+      if (defined(material.pbrMetallicRoughness.baseColorFactor)) {
+        material.pbrMetallicRoughness.baseColorFactor[3] *= transparency;
+      } else {
+        material.pbrMetallicRoughness.baseColorFactor = [1, 1, 1, transparency];
       }
-
-      if (defined(diffuse)) {
-        if (isVec4(diffuse)) {
-          material.pbrMetallicRoughness.baseColorFactor = srgbToLinear(diffuse);
-        } else if (isTexture(diffuse)) {
-          material.pbrMetallicRoughness.baseColorTexture = diffuse;
-        }
-      }
-
-      if (defined(doubleSided)) {
-        material.doubleSided = doubleSided;
-      }
-
-      if (defined(emission)) {
-        if (isVec4(emission)) {
-          material.emissiveFactor = emission.slice(0, 3);
-        } else if (isTexture(emission)) {
-          material.emissiveTexture = emission;
-        }
-      }
-
-      if (defined(transparency)) {
-        if (defined(material.pbrMetallicRoughness.baseColorFactor)) {
-          material.pbrMetallicRoughness.baseColorFactor[3] *= transparency;
-        } else {
-          material.pbrMetallicRoughness.baseColorFactor = [
-            1,
-            1,
-            1,
-            transparency,
-          ];
-        }
-      }
-
-      if (defined(transparent)) {
-        material.alphaMode = transparent ? "BLEND" : "OPAQUE";
-      }
+    }
+    if (defined(transparent)) {
+      material.alphaMode = transparent ? "BLEND" : "OPAQUE";
     }
   });
 

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -888,6 +888,27 @@ describe("updateVersion", () => {
     expect(gltf.extensionsUsed.indexOf("KHR_materials_unlit") !== -1);
   });
 
+  it("updates glTF 1.0 with KHR_materials_common with CONSTANT technique to PBR materials using emissive as the base color texture when diffuse is not present", async () => {
+    const gltf = fsExtra.readJsonSync(gltf1MaterialsCommonTextured);
+    await readResources(gltf, {
+      resourceDirectory: path.dirname(gltf1MaterialsCommonTextured),
+    });
+
+    const materialsCommon =
+      gltf.materials["Effect-Texture"].extensions.KHR_materials_common;
+    // Move the 'diffuse' texture definition into 'emission', and expect
+    // this to show up as the base color texture after the update
+    materialsCommon.values.emission = materialsCommon.values.diffuse;
+    delete materialsCommon.values.diffuse;
+    materialsCommon.technique = "CONSTANT";
+    updateVersion(gltf);
+
+    const material = gltf.materials[0];
+    expect(material.pbrMetallicRoughness.baseColorTexture).toBeDefined();
+    expect(material.extensions.KHR_materials_unlit).toBeDefined();
+    expect(gltf.extensionsUsed.indexOf("KHR_materials_unlit") !== -1);
+  });
+
   it("updates glTF 1.0 with KHR_materials_common with other values to PBR materials", async () => {
     const gltf = fsExtra.readJsonSync(gltf1MaterialsCommon);
     await readResources(gltf, {


### PR DESCRIPTION
Addresses https://github.com/CesiumGS/cesium/issues/11821 
May replace https://github.com/CesiumGS/gltf-pipeline/pull/654

When a `KHR_materials_common` had the [`CONSTANT` technique](https://github.com/KhronosGroup/glTF/blob/main/extensions/1.0/Khronos/KHR_materials_common/README.md#constant), then the resulting PBR material did not contain a base color texture, because the `CONSTANT` technique did not support diffuse textures. However, it could contain ambient or emissive textures. With the change here, the conversion will try to assign the ambient- or emissive texture as the base color texture when the `CONSTANT` technique is used. 