### PR TITLE
Modify the accessor index in EXT_mesh_gpu_instancing, when removing unused accessors.

### DIFF
--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -142,6 +142,26 @@ Remove.accessor = function (gltf, accessorId) {
       }
     });
   });
+
+  if (usesExtension(gltf, "EXT_mesh_gpu_instancing")) {
+    ForEach.node(gltf, function (node) {
+      if (
+        defined(node.extensions) &&
+        defined(node.extensions.EXT_mesh_gpu_instancing)
+      ) {
+        Object.keys(node.extensions.EXT_mesh_gpu_instancing.attributes).forEach(
+          function (key) {
+            const attributeAccessorId =
+              node.extensions.EXT_mesh_gpu_instancing.attributes[key];
+            if (attributeAccessorId > accessorId) {
+              node.extensions.EXT_mesh_gpu_instancing.attributes[key] =
+                attributeAccessorId - 1;
+            }
+          },
+        );
+      }
+    });
+  }
 };
 
 Remove.buffer = function (gltf, bufferId) {


### PR DESCRIPTION
I found that although the accessor referenced by EXT_mesh_gpu_instancing was added to the list of used elements, the accessor index in EXT_mesh_gpu_instancing was not modified when the unused accessor was removed.

#661 