### PR TITLE
Remove use of `defaultValue`

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -11,7 +11,6 @@ const gltfToGlb = require("../lib/gltfToGlb");
 const processGlb = require("../lib/processGlb");
 const processGltf = require("../lib/processGltf");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
 const defaults = processGltf.defaults;
@@ -189,7 +188,7 @@ const length = args.length;
 for (i = 0; i < length; ++i) {
   const arg = args[i];
   if (arg.indexOf("--draco.") === 0 || arg === "-d") {
-    dracoOptions = defaultValue(argv.draco, {});
+    dracoOptions = argv.draco ?? {};
   }
 }
 
@@ -243,7 +242,7 @@ read(inputPath)
     return run(gltf, options);
   })
   .then(function (results) {
-    const gltf = defaultValue(results.gltf, results.glb);
+    const gltf = results.gltf ?? results.glb;
     const separateResources = results.separateResources;
     return Promise.all([
       write(outputPath, gltf, writeOptions),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,6 @@ const path = require("path");
 const Promise = require("bluebird");
 const yargs = require("yargs");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const argv = yargs.argv;
 
@@ -276,7 +275,7 @@ function buildCesium() {
 }
 
 function getLicenseDataFromPackage(packageName, override) {
-  override = defaultValue(override, defaultValue.EMPTY_OBJECT);
+  override = override ?? {};
   const packagePath = path.join("node_modules", packageName, "package.json");
 
   if (!fsExtra.existsSync(packagePath)) {

--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -4,7 +4,6 @@ const addToArray = require("./addToArray");
 const ForEach = require("./ForEach");
 const getAccessorByteStride = require("./getAccessorByteStride");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const WebGLConstants = Cesium.WebGLConstants;
 
@@ -21,19 +20,19 @@ module.exports = addDefaults;
 function addDefaults(gltf) {
   ForEach.accessor(gltf, function (accessor) {
     if (defined(accessor.bufferView)) {
-      accessor.byteOffset = defaultValue(accessor.byteOffset, 0);
+      accessor.byteOffset = accessor.byteOffset ?? 0;
     }
   });
 
   ForEach.bufferView(gltf, function (bufferView) {
     if (defined(bufferView.buffer)) {
-      bufferView.byteOffset = defaultValue(bufferView.byteOffset, 0);
+      bufferView.byteOffset = bufferView.byteOffset ?? 0;
     }
   });
 
   ForEach.mesh(gltf, function (mesh) {
     ForEach.meshPrimitive(mesh, function (primitive) {
-      primitive.mode = defaultValue(primitive.mode, WebGLConstants.TRIANGLES);
+      primitive.mode = primitive.mode ?? WebGLConstants.TRIANGLES;
       if (!defined(primitive.material)) {
         if (!defined(gltf.materials)) {
           gltf.materials = [];
@@ -49,7 +48,7 @@ function addDefaults(gltf) {
   ForEach.accessorContainingVertexAttributeData(gltf, function (accessorId) {
     const accessor = gltf.accessors[accessorId];
     const bufferViewId = accessor.bufferView;
-    accessor.normalized = defaultValue(accessor.normalized, false);
+    accessor.normalized = accessor.normalized ?? false;
     if (defined(bufferViewId)) {
       const bufferView = gltf.bufferViews[bufferViewId];
       bufferView.byteStride = getAccessorByteStride(gltf, accessor);
@@ -67,10 +66,7 @@ function addDefaults(gltf) {
   });
 
   ForEach.material(gltf, function (material) {
-    const extensions = defaultValue(
-      material.extensions,
-      defaultValue.EMPTY_OBJECT,
-    );
+    const extensions = material.extensions ?? {};
     const materialsCommon = extensions.KHR_materials_common;
     if (defined(materialsCommon)) {
       const technique = materialsCommon.technique;
@@ -86,7 +82,7 @@ function addDefaults(gltf) {
         ? values.emission
         : [0.0, 0.0, 0.0, 1.0];
 
-      values.transparency = defaultValue(values.transparency, 1.0);
+      values.transparency = values.transparency ?? 1.0;
 
       if (technique !== "CONSTANT") {
         values.diffuse = defined(values.diffuse)
@@ -96,32 +92,23 @@ function addDefaults(gltf) {
           values.specular = defined(values.specular)
             ? values.specular
             : [0.0, 0.0, 0.0, 1.0];
-          values.shininess = defaultValue(values.shininess, 0.0);
+          values.shininess = values.shininess ?? 0.0;
         }
       }
 
       // These actually exist on the extension object, not the values object despite what's shown in the spec
-      materialsCommon.transparent = defaultValue(
-        materialsCommon.transparent,
-        false,
-      );
-      materialsCommon.doubleSided = defaultValue(
-        materialsCommon.doubleSided,
-        false,
-      );
+      materialsCommon.transparent = materialsCommon.transparent ?? false;
+      materialsCommon.doubleSided = materialsCommon.doubleSided ?? false;
 
       return;
     }
 
-    material.emissiveFactor = defaultValue(
-      material.emissiveFactor,
-      [0.0, 0.0, 0.0],
-    );
-    material.alphaMode = defaultValue(material.alphaMode, "OPAQUE");
-    material.doubleSided = defaultValue(material.doubleSided, false);
+    material.emissiveFactor = material.emissiveFactor ?? [0.0, 0.0, 0.0];
+    material.alphaMode = material.alphaMode ?? "OPAQUE";
+    material.doubleSided = material.doubleSided ?? false;
 
     if (material.alphaMode === "MASK") {
-      material.alphaCutoff = defaultValue(material.alphaCutoff, 0.5);
+      material.alphaCutoff = material.alphaCutoff ?? 0.5;
     }
 
     const techniquesExtension = extensions.KHR_techniques_webgl;
@@ -140,18 +127,12 @@ function addDefaults(gltf) {
 
     const pbrMetallicRoughness = material.pbrMetallicRoughness;
     if (defined(pbrMetallicRoughness)) {
-      pbrMetallicRoughness.baseColorFactor = defaultValue(
-        pbrMetallicRoughness.baseColorFactor,
-        [1.0, 1.0, 1.0, 1.0],
-      );
-      pbrMetallicRoughness.metallicFactor = defaultValue(
-        pbrMetallicRoughness.metallicFactor,
-        1.0,
-      );
-      pbrMetallicRoughness.roughnessFactor = defaultValue(
-        pbrMetallicRoughness.roughnessFactor,
-        1.0,
-      );
+      pbrMetallicRoughness.baseColorFactor =
+        pbrMetallicRoughness.baseColorFactor ?? [1.0, 1.0, 1.0, 1.0];
+      pbrMetallicRoughness.metallicFactor =
+        pbrMetallicRoughness.metallicFactor ?? 1.0;
+      pbrMetallicRoughness.roughnessFactor =
+        pbrMetallicRoughness.roughnessFactor ?? 1.0;
       addTextureDefaults(pbrMetallicRoughness.baseColorTexture);
       addTextureDefaults(pbrMetallicRoughness.metallicRoughnessTexture);
     }
@@ -159,25 +140,19 @@ function addDefaults(gltf) {
     const pbrSpecularGlossiness =
       extensions.KHR_materials_pbrSpecularGlossiness;
     if (defined(pbrSpecularGlossiness)) {
-      pbrSpecularGlossiness.diffuseFactor = defaultValue(
-        pbrSpecularGlossiness.diffuseFactor,
-        [1.0, 1.0, 1.0, 1.0],
-      );
-      pbrSpecularGlossiness.specularFactor = defaultValue(
-        pbrSpecularGlossiness.specularFactor,
-        [1.0, 1.0, 1.0],
-      );
-      pbrSpecularGlossiness.glossinessFactor = defaultValue(
-        pbrSpecularGlossiness.glossinessFactor,
-        1.0,
-      );
+      pbrSpecularGlossiness.diffuseFactor =
+        pbrSpecularGlossiness.diffuseFactor ?? [1.0, 1.0, 1.0, 1.0];
+      pbrSpecularGlossiness.specularFactor =
+        pbrSpecularGlossiness.specularFactor ?? [1.0, 1.0, 1.0];
+      pbrSpecularGlossiness.glossinessFactor =
+        pbrSpecularGlossiness.glossinessFactor ?? 1.0;
       addTextureDefaults(pbrSpecularGlossiness.specularGlossinessTexture);
     }
   });
 
   ForEach.animation(gltf, function (animation) {
     ForEach.animationSampler(animation, function (sampler) {
-      sampler.interpolation = defaultValue(sampler.interpolation, "LINEAR");
+      sampler.interpolation = sampler.interpolation ?? "LINEAR";
     });
   });
 
@@ -190,23 +165,20 @@ function addDefaults(gltf) {
       defined(node.rotation) ||
       defined(node.scale)
     ) {
-      node.translation = defaultValue(node.translation, [0.0, 0.0, 0.0]);
-      node.rotation = defaultValue(node.rotation, [0.0, 0.0, 0.0, 1.0]);
-      node.scale = defaultValue(node.scale, [1.0, 1.0, 1.0]);
+      node.translation = node.translation ?? [0.0, 0.0, 0.0];
+      node.rotation = node.rotation ?? [0.0, 0.0, 0.0, 1.0];
+      node.scale = node.scale ?? [1.0, 1.0, 1.0];
     } else {
-      node.matrix = defaultValue(
-        node.matrix,
-        [
-          1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-          0.0, 1.0,
-        ],
-      );
+      node.matrix = node.matrix ?? [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0,
+      ];
     }
   });
 
   ForEach.sampler(gltf, function (sampler) {
-    sampler.wrapS = defaultValue(sampler.wrapS, WebGLConstants.REPEAT);
-    sampler.wrapT = defaultValue(sampler.wrapT, WebGLConstants.REPEAT);
+    sampler.wrapS = sampler.wrapS ?? WebGLConstants.REPEAT;
+    sampler.wrapT = sampler.wrapT ?? WebGLConstants.REPEAT;
   });
 
   if (defined(gltf.scenes) && !defined(gltf.scene)) {
@@ -234,6 +206,6 @@ function getAnimatedNodes(gltf) {
 
 function addTextureDefaults(texture) {
   if (defined(texture)) {
-    texture.texCoord = defaultValue(texture.texCoord, 0);
+    texture.texCoord = texture.texCoord ?? 0;
   }
 }

--- a/lib/addToArray.js
+++ b/lib/addToArray.js
@@ -1,7 +1,4 @@
 "use strict";
-const Cesium = require("cesium");
-
-const defaultValue = Cesium.defaultValue;
 
 module.exports = addToArray;
 
@@ -15,7 +12,7 @@ module.exports = addToArray;
  * @private
  */
 function addToArray(array, element, checkDuplicates) {
-  checkDuplicates = defaultValue(checkDuplicates, false);
+  checkDuplicates = checkDuplicates ?? false;
   if (checkDuplicates) {
     const index = array.indexOf(element);
     if (index > -1) {

--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -18,7 +18,6 @@ const Cartesian3 = Cesium.Cartesian3;
 const Check = Cesium.Check;
 const clone = Cesium.clone;
 const ComponentDatatype = Cesium.ComponentDatatype;
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const RuntimeError = Cesium.RuntimeError;
 const WebGLConstants = Cesium.WebGLConstants;
@@ -62,21 +61,15 @@ function compressDracoMeshes(gltf, options) {
 }
 
 function compress(gltf, options, encoderModule, decoderModule) {
-  options = defaultValue(options, {});
-  const dracoOptions = defaultValue(options.dracoOptions, {});
+  options = options ?? {};
+  const dracoOptions = options.dracoOptions ?? {};
   const defaults = compressDracoMeshes.defaults;
-  const compressionLevel = defaultValue(
-    dracoOptions.compressionLevel,
-    defaults.compressionLevel,
-  );
-  const uncompressedFallback = defaultValue(
-    dracoOptions.uncompressedFallback,
-    defaults.uncompressedFallback,
-  );
-  const unifiedQuantization = defaultValue(
-    dracoOptions.unifiedQuantization,
-    defaults.unifiedQuantization,
-  );
+  const compressionLevel =
+    dracoOptions.compressionLevel ?? defaults.compressionLevel;
+  const uncompressedFallback =
+    dracoOptions.uncompressedFallback ?? defaults.uncompressedFallback;
+  const unifiedQuantization =
+    dracoOptions.unifiedQuantization ?? defaults.unifiedQuantization;
   const quantizationVolume = dracoOptions.quantizationVolume;
   const explicitQuantization =
     unifiedQuantization || defined(quantizationVolume);
@@ -368,7 +361,7 @@ function addCompressionExtensionToPrimitive(
 
   const bufferViewId = addBuffer(gltf, dracoEncodedBuffer.buffer);
 
-  primitive.extensions = defaultValue(primitive.extensions, {});
+  primitive.extensions = primitive.extensions ?? {};
   primitive.extensions.KHR_draco_mesh_compression = {
     bufferView: bufferViewId,
     attributes: attributeToId,
@@ -395,7 +388,7 @@ function copyCompressedExtensionToPrimitive(primitive, compressedPrimitive) {
 
   const dracoExtension =
     compressedPrimitive.extensions.KHR_draco_mesh_compression;
-  primitive.extensions = defaultValue(primitive.extensions, {});
+  primitive.extensions = primitive.extensions ?? {};
   primitive.extensions.KHR_draco_mesh_compression = {
     bufferView: dracoExtension.bufferView,
     attributes: dracoExtension.attributes,
@@ -465,26 +458,13 @@ function checkRange(name, value, minimum, maximum) {
 function getQuantizationBits(dracoOptions) {
   const defaults = compressDracoMeshes.defaults;
   return {
-    POSITION: defaultValue(
-      dracoOptions.quantizePositionBits,
-      defaults.quantizePositionBits,
-    ),
-    NORMAL: defaultValue(
-      dracoOptions.quantizeNormalBits,
-      defaults.quantizeNormalBits,
-    ),
-    TEXCOORD: defaultValue(
-      dracoOptions.quantizeTexcoordBits,
-      defaults.quantizeTexcoordBits,
-    ),
-    COLOR: defaultValue(
-      dracoOptions.quantizeColorBits,
-      defaults.quantizeColorBits,
-    ),
-    GENERIC: defaultValue(
-      dracoOptions.quantizeGenericBits,
-      defaults.quantizeGenericBits,
-    ),
+    POSITION:
+      dracoOptions.quantizePositionBits ?? defaults.quantizePositionBits,
+    NORMAL: dracoOptions.quantizeNormalBits ?? defaults.quantizeNormalBits,
+    TEXCOORD:
+      dracoOptions.quantizeTexcoordBits ?? defaults.quantizeTexcoordBits,
+    COLOR: dracoOptions.quantizeColorBits ?? defaults.quantizeColorBits,
+    GENERIC: dracoOptions.quantizeGenericBits ?? defaults.quantizeGenericBits,
   };
 }
 

--- a/lib/getJsonBufferPadded.js
+++ b/lib/getJsonBufferPadded.js
@@ -1,7 +1,4 @@
 "use strict";
-const Cesium = require("cesium");
-
-const defaultValue = Cesium.defaultValue;
 
 module.exports = getJsonBufferPadded;
 
@@ -19,7 +16,7 @@ module.exports = getJsonBufferPadded;
  * @private
  */
 function getJsonBufferPadded(json, byteOffset) {
-  byteOffset = defaultValue(byteOffset, 0);
+  byteOffset = byteOffset ?? 0;
   let string = JSON.stringify(json);
 
   const boundary = 8;

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -5,7 +5,6 @@ const BUFFER_MAX_BYTE_LENGTH = Math.min(FS_WRITE_MAX_LENGTH, BUFFER_MAX_LENGTH);
 const Cesium = require("cesium");
 const ForEach = require("./ForEach");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
 module.exports = mergeBuffers;
@@ -24,9 +23,9 @@ function mergeBuffers(gltf, defaultName, force) {
   let baseBufferName = defaultName;
   if (!defined(baseBufferName)) {
     ForEach.buffer(gltf, function (buffer) {
-      baseBufferName = defaultValue(baseBufferName, buffer.name);
+      baseBufferName = baseBufferName ?? buffer.name;
     });
-    baseBufferName = defaultValue(baseBufferName, "buffer");
+    baseBufferName = baseBufferName ?? "buffer";
   }
 
   let buffersByteLength = 0;
@@ -42,10 +41,7 @@ function mergeBuffers(gltf, defaultName, force) {
       emptyBufferIds.push(bufferId);
     }
 
-    const extensions = defaultValue(
-      buffer.extensions,
-      defaultValue.EMPTY_OBJECT,
-    );
+    const extensions = buffer.extensions ?? {};
     const meshoptObject = extensions.EXT_meshopt_compression;
     if (defined(meshoptObject) && meshoptObject.fallback) {
       // Prevent empty meshopt buffer from being merged into main buffer
@@ -161,10 +157,7 @@ function forEachBufferViewLikeObject(gltf, callback) {
   ForEach.bufferView(gltf, function (bufferView) {
     callback(bufferView);
 
-    const extensions = defaultValue(
-      bufferView.extensions,
-      defaultValue.EMPTY_OBJECT,
-    );
+    const extensions = bufferView.extensions ?? {};
     const meshoptObject = extensions.EXT_meshopt_compression;
     if (defined(meshoptObject)) {
       // The EXT_meshopt_compression object has buffer, byteOffset, and byteLength properties like a bufferView

--- a/lib/moveTechniqueRenderStates.js
+++ b/lib/moveTechniqueRenderStates.js
@@ -4,7 +4,6 @@ const Cesium = require("cesium");
 const addExtensionsUsed = require("./addExtensionsUsed");
 const ForEach = require("./ForEach");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const WebGLConstants = Cesium.WebGLConstants;
 
@@ -90,10 +89,8 @@ function moveTechniqueRenderStates(gltf) {
             defined(blendFunctions.blendFuncSeparate))
         ) {
           blendingForTechnique[techniqueIndex] = {
-            blendEquation: defaultValue(
-              blendFunctions.blendEquationSeparate,
-              defaultBlendEquation,
-            ),
+            blendEquation:
+              blendFunctions.blendEquationSeparate ?? defaultBlendEquation,
             blendFactors: getSupportedBlendFactors(
               blendFunctions.blendFuncSeparate,
               defaultBlendFactors,

--- a/lib/parseGlb.js
+++ b/lib/parseGlb.js
@@ -3,7 +3,6 @@ const Cesium = require("cesium");
 const addPipelineExtras = require("./addPipelineExtras");
 const removeExtensionsUsed = require("./removeExtensionsUsed");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const getMagic = Cesium.getMagic;
 const getStringFromTypedArray = Cesium.getStringFromTypedArray;
@@ -77,10 +76,7 @@ function parseGlbVersion1(glb, header) {
   const buffers = gltf.buffers;
   if (defined(buffers) && Object.keys(buffers).length > 0) {
     // In some older models, the binary glTF buffer is named KHR_binary_glTF
-    const binaryGltfBuffer = defaultValue(
-      buffers.binary_glTF,
-      buffers.KHR_binary_glTF,
-    );
+    const binaryGltfBuffer = buffers.binary_glTF ?? buffers.KHR_binary_glTF;
     if (defined(binaryGltfBuffer)) {
       binaryGltfBuffer.extras._pipeline.source = binaryBuffer;
       delete binaryGltfBuffer.uri;

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -13,7 +13,6 @@ const writeResources = require("./writeResources");
 const compressDracoMeshes = require("./compressDracoMeshes");
 
 const clone = Cesium.clone;
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
 module.exports = processGltf;
@@ -39,15 +38,14 @@ module.exports = processGltf;
 function processGltf(gltf, options) {
   const defaults = processGltf.defaults;
   options = defined(options) ? clone(options) : {};
-  options.separateBuffers = defaultValue(options.separate, defaults.separate);
-  options.separateShaders = defaultValue(options.separate, defaults.separate);
+  options.separateBuffers = options.separate ?? defaults.separate;
+  options.separateShaders = options.separate ?? defaults.separate;
   options.separateTextures =
-    defaultValue(options.separateTextures, defaults.separateTextures) ||
-    options.separate;
-  options.stats = defaultValue(options.stats, defaults.stats);
-  options.logger = defaultValue(options.logger, getDefaultLogger());
+    (options.separateTextures ?? defaults.separateTextures) || options.separate;
+  options.stats = options.stats ?? defaults.stats;
+  options.logger = options.logger ?? getDefaultLogger();
   options.separateResources = {};
-  options.customStages = defaultValue(options.customStages, []);
+  options.customStages = options.customStages ?? [];
 
   const preStages = [
     addPipelineExtras,

--- a/lib/readResources.js
+++ b/lib/readResources.js
@@ -11,7 +11,6 @@ const { fileURLToPath, pathToFileURL } = require("./FileUrl");
 const ForEach = require("./ForEach");
 
 const defined = Cesium.defined;
-const defaultValue = Cesium.defaultValue;
 const isDataUri = Cesium.isDataUri;
 const RuntimeError = Cesium.RuntimeError;
 
@@ -31,7 +30,7 @@ module.exports = readResources;
  */
 function readResources(gltf, options) {
   addPipelineExtras(gltf);
-  options = defaultValue(options, {});
+  options = options ?? {};
 
   // Make sure its an absolute path with a trailing separator
   options.resourceDirectory = defined(options.resourceDirectory)
@@ -121,7 +120,7 @@ function readBufferView(gltf, bufferViewId, object, saveResourceId) {
   const bufferView = gltf.bufferViews[bufferViewId];
   const buffer = gltf.buffers[bufferView.buffer];
   const source = buffer.extras._pipeline.source;
-  const byteOffset = defaultValue(bufferView.byteOffset, 0);
+  const byteOffset = bufferView.byteOffset ?? 0;
   return source.slice(byteOffset, byteOffset + bufferView.byteLength);
 }
 

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -4,7 +4,6 @@ const ForEach = require("./ForEach");
 const forEachTextureInMaterial = require("./forEachTextureInMaterial");
 const usesExtension = require("./usesExtension");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
 module.exports = removeUnusedElements;
@@ -30,7 +29,7 @@ const allElementTypes = [
  * @private
  */
 function removeUnusedElements(gltf, elementTypes) {
-  elementTypes = defaultValue(elementTypes, allElementTypes);
+  elementTypes = elementTypes ?? allElementTypes;
   allElementTypes.forEach(function (type) {
     if (elementTypes.indexOf(type) > -1) {
       removeUnusedElementsByType(gltf, type);

--- a/lib/splitPrimitives.js
+++ b/lib/splitPrimitives.js
@@ -10,7 +10,6 @@ const removeUnusedElements = require("./removeUnusedElements");
 
 const clone = Cesium.clone;
 const ComponentDatatype = Cesium.ComponentDatatype;
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const numberOfComponentsForType = Cesium.numberOfComponentsForType;
 
@@ -45,7 +44,7 @@ function splitPrimitives(gltf) {
         mode: primitive.mode,
       });
       if (defined(hashPrimitives[hashPrimitive])) {
-        const duplicates = defaultValue(duplicatePrimitives[hashPrimitive], []);
+        const duplicates = duplicatePrimitives[hashPrimitive] ?? [];
         duplicatePrimitives[hashPrimitive] = duplicates;
         duplicates.push(primitive);
         return;
@@ -57,10 +56,8 @@ function splitPrimitives(gltf) {
         targets: primitive.targets,
         mode: primitive.mode,
       });
-      const primitivesShared = defaultValue(
-        primitivesWithSharedAttributes[hashAttributes],
-        [],
-      );
+      const primitivesShared =
+        primitivesWithSharedAttributes[hashAttributes] ?? [];
       primitivesWithSharedAttributes[hashAttributes] = primitivesShared;
       primitivesShared.push(primitive);
     });

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -16,7 +16,6 @@ const Cartesian3 = Cesium.Cartesian3;
 const Cartesian4 = Cesium.Cartesian4;
 const clone = Cesium.clone;
 const ComponentDatatype = Cesium.ComponentDatatype;
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const Matrix4 = Cesium.Matrix4;
 const Quaternion = Cesium.Quaternion;
@@ -45,16 +44,16 @@ const updateFunctions = {
  * @private
  */
 function updateVersion(gltf, options) {
-  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  options = options ?? {};
   const targetVersion = options.targetVersion;
   let version = gltf.version;
 
-  gltf.asset = defaultValue(gltf.asset, {
+  gltf.asset = gltf.asset ?? {
     version: "1.0",
-  });
+  };
 
-  gltf.asset.version = defaultValue(gltf.asset.version, "1.0");
-  version = defaultValue(version, gltf.asset.version).toString();
+  gltf.asset.version = gltf.asset.version ?? "1.0";
+  version = (version ?? gltf.asset.version).toString();
 
   // Invalid version
   if (!Object.prototype.hasOwnProperty.call(updateFunctions, version)) {
@@ -112,11 +111,8 @@ function setPrimitiveModes(gltf) {
         const primitivesLength = primitives.length;
         for (let i = 0; i < primitivesLength; ++i) {
           const primitive = primitives[i];
-          const defaultMode = defaultValue(
-            primitive.primitive,
-            WebGLConstants.TRIANGLES,
-          );
-          primitive.mode = defaultValue(primitive.mode, defaultMode);
+          const defaultMode = primitive.primitive ?? WebGLConstants.TRIANGLES;
+          primitive.mode = primitive.mode ?? defaultMode;
           delete primitive.primitive;
         }
       }
@@ -210,23 +206,15 @@ function removeTechniquePasses(gltf) {
       const technique = techniques[techniqueId];
       const passes = technique.passes;
       if (defined(passes)) {
-        const passName = defaultValue(technique.pass, "defaultPass");
+        const passName = technique.pass ?? "defaultPass";
         if (Object.prototype.hasOwnProperty.call(passes, passName)) {
           const pass = passes[passName];
           const instanceProgram = pass.instanceProgram;
-          technique.attributes = defaultValue(
-            technique.attributes,
-            instanceProgram.attributes,
-          );
-          technique.program = defaultValue(
-            technique.program,
-            instanceProgram.program,
-          );
-          technique.uniforms = defaultValue(
-            technique.uniforms,
-            instanceProgram.uniforms,
-          );
-          technique.states = defaultValue(technique.states, pass.states);
+          technique.attributes =
+            technique.attributes ?? instanceProgram.attributes;
+          technique.program = technique.program ?? instanceProgram.program;
+          technique.uniforms = technique.uniforms ?? instanceProgram.uniforms;
+          technique.states = technique.states ?? pass.states;
         }
         delete technique.passes;
         delete technique.pass;
@@ -274,9 +262,9 @@ function glTF08to10(gltf) {
   }
   // gltf.lights -> khrMaterialsCommon.lights
   if (defined(gltf.lights)) {
-    const extensions = defaultValue(gltf.extensions, {});
+    const extensions = gltf.extensions ?? {};
     gltf.extensions = extensions;
-    const materialsCommon = defaultValue(extensions.KHR_materials_common, {});
+    const materialsCommon = extensions.KHR_materials_common ?? {};
     extensions.KHR_materials_common = materialsCommon;
     materialsCommon.lights = gltf.lights;
     delete gltf.lights;
@@ -616,7 +604,7 @@ const knownExtensions = {
 };
 function requireKnownExtensions(gltf) {
   const extensionsUsed = gltf.extensionsUsed;
-  gltf.extensionsRequired = defaultValue(gltf.extensionsRequired, []);
+  gltf.extensionsRequired = gltf.extensionsRequired ?? [];
   if (defined(extensionsUsed)) {
     const extensionsUsedLength = extensionsUsed.length;
     for (let i = 0; i < extensionsUsedLength; ++i) {
@@ -773,7 +761,7 @@ function requireByteLength(gltf) {
       const accessorByteEnd =
         accessor.byteOffset + accessor.count * accessorByteStride;
       bufferView.byteLength = Math.max(
-        defaultValue(bufferView.byteLength, 0),
+        bufferView.byteLength ?? 0,
         accessorByteEnd,
       );
     }
@@ -798,10 +786,8 @@ function moveByteStrideToBufferView(gltf) {
   const bufferViewMap = {};
   ForEach.accessor(gltf, function (accessor) {
     if (defined(accessor.bufferView)) {
-      bufferViewMap[accessor.bufferView] = defaultValue(
-        bufferViewMap[accessor.bufferView],
-        [],
-      );
+      bufferViewMap[accessor.bufferView] =
+        bufferViewMap[accessor.bufferView] ?? [];
       bufferViewMap[accessor.bufferView].push(accessor);
     }
   });
@@ -960,7 +946,7 @@ function validatePresentAccessorMinMax(gltf) {
 }
 
 function glTF10to20(gltf) {
-  gltf.asset = defaultValue(gltf.asset, {});
+  gltf.asset = gltf.asset ?? {};
   gltf.asset.version = "2.0";
   // material.instanceTechnique properties should be directly on the material. instanceTechnique is a gltf 0.8 property but is seen in some 1.0 models.
   updateInstanceTechniques(gltf);
@@ -1057,15 +1043,11 @@ function srgbToLinear(srgb) {
 }
 
 function convertTechniquesToPbr(gltf, options) {
-  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-  const baseColorTextureNames = defaultValue(
-    options.baseColorTextureNames,
-    defaultBaseColorTextureNames,
-  );
-  const baseColorFactorNames = defaultValue(
-    options.baseColorFactorNames,
-    defaultBaseColorFactorNames,
-  );
+  options = options ?? {};
+  const baseColorTextureNames =
+    options.baseColorTextureNames ?? defaultBaseColorTextureNames;
+  const baseColorFactorNames =
+    options.baseColorFactorNames ?? defaultBaseColorFactorNames;
 
   // Future work: convert other values like emissive, specular, etc. Only handling diffuse right now.
   ForEach.material(gltf, function (material) {
@@ -1107,16 +1089,13 @@ function assignAsEmissive(material, emissive) {
 function convertMaterialsCommonToPbr(gltf) {
   // Future work: convert KHR_materials_common lights to KHR_lights_punctual
   ForEach.material(gltf, function (material) {
-    const materialsCommon = defaultValue(
-      material.extensions,
-      defaultValue.EMPTY_OBJECT,
-    ).KHR_materials_common;
+    const materialsCommon = (material.extensions ?? {}).KHR_materials_common;
     if (!defined(materialsCommon)) {
       // Nothing to do
       return;
     }
 
-    const values = defaultValue(materialsCommon.values, {});
+    const values = materialsCommon.values ?? {};
     const ambient = values.ambient;
     const diffuse = values.diffuse;
     const emission = values.emission;

--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -7,7 +7,6 @@ const getImageExtension = require("./getImageExtension");
 const mergeBuffers = require("./mergeBuffers");
 const removeUnusedElements = require("./removeUnusedElements");
 
-const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 const WebGLConstants = Cesium.WebGLConstants;
 
@@ -40,12 +39,12 @@ module.exports = writeResources;
  * @private
  */
 function writeResources(gltf, options) {
-  options = defaultValue(options, {});
-  options.separateBuffers = defaultValue(options.separateBuffers, false);
-  options.separateTextures = defaultValue(options.separateTextures, false);
-  options.separateShaders = defaultValue(options.separateShaders, false);
-  options.dataUris = defaultValue(options.dataUris, false);
-  options.forceMergeBuffers = defaultValue(options.forceMergeBuffers, false);
+  options = options ?? {};
+  options.separateBuffers = options.separateBuffers ?? false;
+  options.separateTextures = options.separateTextures ?? false;
+  options.separateShaders = options.separateShaders ?? false;
+  options.dataUris = options.dataUris ?? false;
+  options.forceMergeBuffers = options.forceMergeBuffers ?? false;
 
   // Remember which of the resources have been written, so we can re-use them.
   const writtenResourceMap = {};


### PR DESCRIPTION
I'll open this despite the open question of [What's the future of `gltf-pipeline`?](https://github.com/CesiumGS/gltf-pipeline/issues/670) (or rather, to prevent the short-term answer to that "being broken"):

The `defaultValue` function has been deprecated in CesiumJS, and is scheduled for removal in a few months. The `gltf-pipeline` library is stil used in several projects (with one of them being CesiumJS itself...). This PR removes the use of `defaultValue` throughout the codebase, and replaces it with the nullish coalescing operator. 

(Note: This will likely cause merge conflicts with https://github.com/CesiumGS/gltf-pipeline/pull/669 . Depending on the timeline, we _will_ have to fix the `defaultValue` deprecation _first_. In doubt, it should probably be possible to create a "replace-all"-regex for the changes here. I just did them manually, because they have _just so_ been below the threshold where an automation seemed worthwhile, but that's subjective). 


