### PR TITLE
Backport specular handling from CesiumJS

### DIFF
--- a/lib/forEachTextureInMaterial.js
+++ b/lib/forEachTextureInMaterial.js
@@ -39,10 +39,11 @@ function forEachTextureInMaterial(material, handler) {
     }
   }
 
-  if (defined(material.extensions)) {
+  const { extensions } = material;
+  if (defined(extensions)) {
     // Spec gloss extension
     const pbrSpecularGlossiness =
-      material.extensions.KHR_materials_pbrSpecularGlossiness;
+      extensions.KHR_materials_pbrSpecularGlossiness;
     if (defined(pbrSpecularGlossiness)) {
       if (defined(pbrSpecularGlossiness.diffuseTexture)) {
         const textureInfo = pbrSpecularGlossiness.diffuseTexture;
@@ -60,13 +61,28 @@ function forEachTextureInMaterial(material, handler) {
       }
     }
 
+    // Specular extension
+    const specular = extensions.KHR_materials_specular;
+    if (defined(specular)) {
+      const { specularTexture, specularColorTexture } = specular;
+      if (defined(specularTexture)) {
+        const value = handler(specularTexture.index, specularTexture);
+        if (defined(value)) {
+          return value;
+        }
+      }
+      if (defined(specularColorTexture)) {
+        const value = handler(specularColorTexture.index, specularColorTexture);
+        if (defined(value)) {
+          return value;
+        }
+      }
+    }
+
     // Materials common extension (may be present in models converted from glTF 1.0)
-    const materialsCommon = material.extensions.KHR_materials_common;
+    const materialsCommon = extensions.KHR_materials_common;
     if (defined(materialsCommon) && defined(materialsCommon.values)) {
-      const diffuse = materialsCommon.values.diffuse;
-      const ambient = materialsCommon.values.ambient;
-      const emission = materialsCommon.values.emission;
-      const specular = materialsCommon.values.specular;
+      const { diffuse, ambient, emission, specular } = materialsCommon.values;
       if (defined(diffuse) && defined(diffuse.index)) {
         const value = handler(diffuse.index, diffuse);
         if (defined(value)) {


### PR DESCRIPTION
This is just adding support for `KHR_materials_specular`, by calling a handler for the respective textures from this extension in `forEachTextureInMaterial`

This was originally added in CesiumJS, via https://github.com/CesiumGS/cesium/pull/11970 , at https://github.com/CesiumGS/cesium/commit/59141130b72a7d43f3e30eb56e45ec99255edad3#diff-6a3b6ddf82583b7f0637f12718da327f21acabf8e5dac921f0fb13c0b9150869R36

