### PR TITLE
Account for extension textures in forEachTextureInMaterial (#660)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Next release
+
+- Account for textures defined by the `KHR_materials_clearcoat`, `KHR_materials_anisotropy`, `KHR_materials_sheen`, `KHR_materials_iridescence`, and `KHR_materials_volume` extensions in `forEachTextureInMaterial`. [#660](https://github.com/CesiumGS/gltf-pipeline/issues/660)
+
 ### 4.3.1 - 2026-04-03
 
 - Fixed handling of glTF models with the [`KHR_materials_transmission`](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_transmission/README.md) extension. [#678](https://github.com/CesiumGS/gltf-pipeline/pull/678)

--- a/lib/forEachTextureInMaterial.js
+++ b/lib/forEachTextureInMaterial.js
@@ -89,6 +89,102 @@ function forEachTextureInMaterial(material, handler) {
       }
     }
 
+    // Clearcoat extension
+    const clearcoat = extensions.KHR_materials_clearcoat;
+    if (defined(clearcoat)) {
+      const {
+        clearcoatTexture,
+        clearcoatRoughnessTexture,
+        clearcoatNormalTexture,
+      } = clearcoat;
+      if (defined(clearcoatTexture)) {
+        const value = handler(clearcoatTexture.index, clearcoatTexture);
+        if (defined(value)) {
+          return value;
+        }
+      }
+      if (defined(clearcoatRoughnessTexture)) {
+        const value = handler(
+          clearcoatRoughnessTexture.index,
+          clearcoatRoughnessTexture,
+        );
+        if (defined(value)) {
+          return value;
+        }
+      }
+      if (defined(clearcoatNormalTexture)) {
+        const value = handler(
+          clearcoatNormalTexture.index,
+          clearcoatNormalTexture,
+        );
+        if (defined(value)) {
+          return value;
+        }
+      }
+    }
+
+    // Anisotropy extension
+    const anisotropy = extensions.KHR_materials_anisotropy;
+    if (defined(anisotropy) && defined(anisotropy.anisotropyTexture)) {
+      const textureInfo = anisotropy.anisotropyTexture;
+      const value = handler(textureInfo.index, textureInfo);
+      if (defined(value)) {
+        return value;
+      }
+    }
+
+    // Sheen extension
+    const sheen = extensions.KHR_materials_sheen;
+    if (defined(sheen)) {
+      const { sheenColorTexture, sheenRoughnessTexture } = sheen;
+      if (defined(sheenColorTexture)) {
+        const value = handler(sheenColorTexture.index, sheenColorTexture);
+        if (defined(value)) {
+          return value;
+        }
+      }
+      if (defined(sheenRoughnessTexture)) {
+        const value = handler(
+          sheenRoughnessTexture.index,
+          sheenRoughnessTexture,
+        );
+        if (defined(value)) {
+          return value;
+        }
+      }
+    }
+
+    // Iridescence extension
+    const iridescence = extensions.KHR_materials_iridescence;
+    if (defined(iridescence)) {
+      const { iridescenceTexture, iridescenceThicknessTexture } = iridescence;
+      if (defined(iridescenceTexture)) {
+        const value = handler(iridescenceTexture.index, iridescenceTexture);
+        if (defined(value)) {
+          return value;
+        }
+      }
+      if (defined(iridescenceThicknessTexture)) {
+        const value = handler(
+          iridescenceThicknessTexture.index,
+          iridescenceThicknessTexture,
+        );
+        if (defined(value)) {
+          return value;
+        }
+      }
+    }
+
+    // Volume extension
+    const volume = extensions.KHR_materials_volume;
+    if (defined(volume) && defined(volume.thicknessTexture)) {
+      const textureInfo = volume.thicknessTexture;
+      const value = handler(textureInfo.index, textureInfo);
+      if (defined(value)) {
+        return value;
+      }
+    }
+
     // Materials common extension (may be present in models converted from glTF 1.0)
     const materialsCommon = extensions.KHR_materials_common;
     if (defined(materialsCommon) && defined(materialsCommon.values)) {

--- a/specs/lib/forEachTextureInMaterialSpec.js
+++ b/specs/lib/forEachTextureInMaterialSpec.js
@@ -1,0 +1,118 @@
+"use strict";
+const forEachTextureInMaterial = require("../../lib/forEachTextureInMaterial");
+
+describe("forEachTextureInMaterial", () => {
+  function collectIndices(material) {
+    const indices = [];
+    forEachTextureInMaterial(material, (index) => {
+      indices.push(index);
+    });
+    return indices;
+  }
+
+  it("visits pbrMetallicRoughness textures", () => {
+    const material = {
+      pbrMetallicRoughness: {
+        baseColorTexture: { index: 0 },
+        metallicRoughnessTexture: { index: 1 },
+      },
+    };
+    expect(collectIndices(material)).toEqual([0, 1]);
+  });
+
+  it("visits top level textures", () => {
+    const material = {
+      emissiveTexture: { index: 0 },
+      normalTexture: { index: 1 },
+      occlusionTexture: { index: 2 },
+    };
+    expect(collectIndices(material)).toEqual([0, 1, 2]);
+  });
+
+  it("visits KHR_materials_clearcoat textures", () => {
+    const material = {
+      extensions: {
+        KHR_materials_clearcoat: {
+          clearcoatTexture: { index: 0 },
+          clearcoatRoughnessTexture: { index: 1 },
+          clearcoatNormalTexture: { index: 2 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([0, 1, 2]);
+  });
+
+  it("visits KHR_materials_anisotropy texture", () => {
+    const material = {
+      extensions: {
+        KHR_materials_anisotropy: {
+          anisotropyTexture: { index: 3 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([3]);
+  });
+
+  it("visits KHR_materials_sheen textures", () => {
+    const material = {
+      extensions: {
+        KHR_materials_sheen: {
+          sheenColorTexture: { index: 0 },
+          sheenRoughnessTexture: { index: 1 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([0, 1]);
+  });
+
+  it("visits KHR_materials_iridescence textures", () => {
+    const material = {
+      extensions: {
+        KHR_materials_iridescence: {
+          iridescenceTexture: { index: 0 },
+          iridescenceThicknessTexture: { index: 1 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([0, 1]);
+  });
+
+  it("visits KHR_materials_volume texture", () => {
+    const material = {
+      extensions: {
+        KHR_materials_volume: {
+          thicknessTexture: { index: 4 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([4]);
+  });
+
+  it("visits KHR_materials_specular and KHR_materials_transmission textures", () => {
+    const material = {
+      extensions: {
+        KHR_materials_specular: {
+          specularTexture: { index: 0 },
+          specularColorTexture: { index: 1 },
+        },
+        KHR_materials_transmission: {
+          transmissionTexture: { index: 2 },
+        },
+      },
+    };
+    expect(collectIndices(material)).toEqual([0, 1, 2]);
+  });
+
+  it("returns early when the handler returns a value", () => {
+    const material = {
+      extensions: {
+        KHR_materials_clearcoat: {
+          clearcoatTexture: { index: 5 },
+          clearcoatRoughnessTexture: { index: 6 },
+        },
+      },
+    };
+    const result = forEachTextureInMaterial(material, (index) => index);
+    expect(result).toBe(5);
+  });
+});


### PR DESCRIPTION
## Fixes

Fixes #660

## Problem

`forEachTextureInMaterial` only iterated over a fixed set of texture sources: `pbrMetallicRoughness`, `KHR_materials_pbrSpecularGlossiness`, `KHR_materials_specular`, `KHR_materials_transmission`, `KHR_materials_common`, `KHR_techniques_webgl`, and the top-level `emissiveTexture`/`normalTexture`/`occlusionTexture`. Textures defined by several newer glTF PBR extensions were never visited.

## Root Cause

The function predates a number of ratified material extensions that add their own textures. Because those textures are not enumerated, consumers of this helper (e.g. `removeUnusedElements`) can incorrectly classify the referenced textures, images, and samplers as unused and strip them.

## Solution

Visit textures defined by the following extensions, following the existing handler / early-return pattern used throughout the function:

- `KHR_materials_clearcoat` — `clearcoatTexture`, `clearcoatRoughnessTexture`, `clearcoatNormalTexture`
- `KHR_materials_anisotropy` — `anisotropyTexture`
- `KHR_materials_sheen` — `sheenColorTexture`, `sheenRoughnessTexture`
- `KHR_materials_iridescence` — `iridescenceTexture`, `iridescenceThicknessTexture`
- `KHR_materials_volume` — `thicknessTexture`

`KHR_materials_specular` (also mentioned in the issue) was already handled.

## Testing

Added `specs/lib/forEachTextureInMaterialSpec.js` with coverage for each texture source and the early-return behavior.

```
npx jasmine --config=specs/jasmine.json
# 197 specs, 0 failures
```

eslint and prettier are clean.

## Risk Assessment

Low. The change is purely additive — it only adds new `if (defined(...))` branches guarded on the presence of each extension, and does not alter any existing traversal. Behavior for materials without these extensions is unchanged. The main downstream effect is that `removeUnusedElements` will now correctly retain textures referenced solely through these extensions.
